### PR TITLE
CI: Validate with Python 3.12 only

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -18,13 +18,13 @@ concurrency:
 jobs:
   package:
     name: Package
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.12'
 
     - name: Check Python version
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     name: Release
     environment: release
     needs: [ test, package ]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     permissions:
       contents: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,70 +30,10 @@ jobs:
         # NOTE: Testing of the Windows targets are currently disabled because
         #       the test script is simply not ready for it.
         target:
-        # Python 3.6
-        - python: '3.6'
-          os: Linux
-          builder: ubuntu-20.04
-        - python: '3.6'
-          os: macOS
-          builder: macos-13
-        # - python: '3.6'
-        #   os: Windows
-        #   builder: windows-2019
-        # Python 3.7
-        - python: '3.7'
-          os: Linux
-          builder: ubuntu-20.04
-        - python: '3.7'
-          os: macOS
-          builder: macos-12
-        # - python: '3.7'
-        #   os: Windows
-        #   builder: windows-2019
-        # Python 3.8
-        - python: '3.8'
-          os: Linux
-          builder: ubuntu-20.04
-        - python: '3.8'
-          os: macOS
-          builder: macos-13
-        # - python: '3.8'
-        #   os: Windows
-        #   builder: windows-2019
-        # Python 3.9
-        - python: '3.9'
-          os: Linux
-          builder: ubuntu-20.04
-        - python: '3.9'
-          os: macOS
-          builder: macos-13
-        # - python: '3.9'
-        #   os: Windows
-        #   builder: windows-2019
-        # Python 3.10
-        - python: '3.10'
-          os: Linux
-          builder: ubuntu-22.04
-        - python: '3.10'
-          os: macOS
-          builder: macos-14
-        # - python: '3.10'
-        #   os: Windows
-        #   builder: windows-2022
-        # Python 3.11
-        - python: '3.11'
-          os: Linux
-          builder: ubuntu-22.04
-        - python: '3.11'
-          os: macOS
-          builder: macos-14
-        # - python: '3.11'
-        #   os: Windows
-        #   builder: windows-2022
         # Python 3.12
         - python: '3.12'
           os: Linux
-          builder: ubuntu-22.04
+          builder: ubuntu-24.04
         - python: '3.12'
           os: macOS
           builder: macos-14


### PR DESCRIPTION
This change simplifies CI validation by testing only Python 3.12, removing multi-version Python testing that had increased CI pipeline time.