### PR TITLE
Check empty strings on macro expansion

### DIFF
--- a/kconfiglib.py
+++ b/kconfiglib.py
@@ -2612,7 +2612,7 @@ class Kconfig(object):
             else:
                 break
 
-        if s.isspace():
+        if not s or s.isspace():
             # We also accept a bare macro on a line (e.g.
             # $(warning-if,$(foo),ops)), provided it expands to a blank string
             return


### PR DESCRIPTION
During macro expansion, bare macros on a line are accepted by the parser as long as they resolve to blank strings. The problem is that the script is currently checking using isspace, so it's actually not checking for blank strings.

This causes the parsing to fail when a macro is the last line of a file, and no newline character is added afterwards. This patch adds a check for the string itself being empty.