### PR TITLE
Handle NULL character as input properly

### DIFF
--- a/menuconfig.py
+++ b/menuconfig.py
@@ -1762,6 +1762,9 @@ def _input_dialog(title, initial_text, info_text=None):
             _safe_curs_set(0)
             return None
 
+        elif c == "\0":  # \0 = NUL, ignore
+            pass
+
         else:
             s, i, hscroll = _edit_text(c, s, i, hscroll, edit_width())
 
@@ -2200,6 +2203,9 @@ def _jump_to_dialog():
 
         elif c == curses.KEY_HOME:
             sel_node_i = scroll = 0
+
+        elif c == "\0":  # \0 = NUL, ignore
+            pass
 
         else:
             s, s_i, hscroll = _edit_text(c, s, s_i, hscroll,


### PR DESCRIPTION
Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/33212

Ignoring when user inputs NULL in a text field.
menuconfig exits with a python stack trace if NULL is provided as input character, therefore ignore NULL as an input character to prevent this behaviour.

A NULL character may be given accidentally by the user through the following ways:
- Pressing `Win` key on keyboard (Windows only)
- Pressing `<CTRL>-@` / `<CTRL>-2`.