### PR TITLE
Add symbol value origin tracking

### DIFF
--- a/tests/Korigins
+++ b/tests/Korigins
@@ -1,0 +1,26 @@
+config MAIN_FLAG
+	bool
+
+config MAIN_FLAG_DEPENDENCY
+	bool "Enable Dependency for Main Feature"
+	default y
+	depends on MAIN_FLAG
+
+config MAIN_FLAG_SELECT
+	bool "Select Main Feature Option"
+	select MAIN_FLAG
+
+choice MULTIPLE_CHOICES
+	prompt "Multiple Choice Option"
+
+config FIRST_CHOICE
+	bool "First Choice Option"
+	depends on !MAIN_FLAG
+
+config SECOND_CHOICE
+	bool "Second Choice Option"
+
+endchoice
+
+config UNSET_FLAG
+	bool "Disabled Feature"


### PR DESCRIPTION
Track the origin of configuration symbol values through a new 'origin' property. This allows users to understand how and where each symbol's value was determined.

Features:
- Track 5 kinds of value origins: assign, default, select, imply, unset
- Record location information (filename, line number) for value sources
- Refactor MenuNode to use 'loc' tuple instead of separate filename/linenr
- Maintain backward compatibility with filename/linenr properties
- Extend set_value() API with optional 'loc' parameter

The implementation provides detailed insight into configuration symbol derivation, which is valuable for debugging complex Kconfig scenarios.

Based on zephyrproject-rtos/Kconfiglib#18 by Luca Burelli.