### PR TITLE
Support 'depends on A if B' syntax

### DIFF
--- a/tests/Kconddep
+++ b/tests/Kconddep
@@ -1,0 +1,28 @@
+# Test conditional dependencies: "depends on A if B"
+# Should be equivalent to "depends on !B || A"
+
+config COND_DEP_1
+    bool
+    depends on A if B
+
+config COND_DEP_2
+    bool
+    depends on (C && D) if E
+
+config COND_DEP_MIXED
+    bool
+    depends on A
+    depends on B if C
+    depends on D
+
+# Test with choice
+choice COND_CHOICE
+    bool "conditional choice"
+    depends on X if Y
+endchoice
+
+# Test multiple conditional dependencies combined
+config MULTI_COND
+    bool
+    depends on A if B
+    depends on C if D

--- a/testsuite.py
+++ b/testsuite.py
@@ -1324,6 +1324,30 @@ tests/Krecursive2:1
                  "A || B || C")
 
 
+    print("Testing conditional dependencies (depends on A if B)")
+
+    c = Kconfig("Kconfiglib/tests/Kconddep")
+
+    # "depends on A if B" should become "!B || A"
+    verify_equal(expr_str(c.syms["COND_DEP_1"].direct_dep), "!B || A")
+
+    # "depends on (C && D) if E" should become "!E || (C && D)"
+    verify_equal(expr_str(c.syms["COND_DEP_2"].direct_dep), "!E || (C && D)")
+
+    # Multiple depends combined: "depends on A", "depends on B if C", "depends on D"
+    # Should become: "A && (!C || B) && D"
+    verify_equal(expr_str(c.syms["COND_DEP_MIXED"].direct_dep),
+                 "A && (!C || B) && D")
+
+    # Test with choice
+    verify_equal(expr_str(c.named_choices["COND_CHOICE"].direct_dep), "!Y || X")
+
+    # Multiple conditional dependencies: "depends on A if B" and "depends on C if D"
+    # Should become: "(!B || A) && (!D || C)"
+    verify_equal(expr_str(c.syms["MULTI_COND"].direct_dep),
+                 "(!B || A) && (!D || C)")
+
+
     print("Testing expr_items()")
 
     c = Kconfig("Kconfiglib/tests/Kexpr_items")


### PR DESCRIPTION
This extends the "depends on" syntax to support conditional dependencies with "depends on A if B". This is functionally equivalent to "depends on !B || A" but significantly more readable.

Implementation converts "A if B" to "!B || A" during parsing:
- When B is false, dependency is always satisfied
- When B is true, dependency becomes A