### PR TITLE
Fix Symbol.ranges unpacking

### DIFF
--- a/guiconfig.py
+++ b/guiconfig.py
@@ -1844,23 +1844,23 @@ def _check_valid(dialog, entry, sym, s):
     # Returns True if the string 's' is a well-formed value for 'sym'.
     # Otherwise, pops up an error and returns False.
 
-    if sym.type not in (INT, HEX):
+    if sym.orig_type not in (INT, HEX):
         # Anything goes for non-int/hex symbols
         return True
 
-    base = 10 if sym.type == INT else 16
+    base = 10 if sym.orig_type == INT else 16
     try:
         int(s, base)
     except ValueError:
         messagebox.showerror(
             "Bad value",
-            "'{}' is a malformed {} value".format(s, TYPE_TO_STR[sym.type]),
+            "'{}' is a malformed {} value".format(s, TYPE_TO_STR[sym.orig_type]),
             parent=dialog,
         )
         entry.focus_set()
         return False
 
-    for low_sym, high_sym, cond in sym.ranges:
+    for low_sym, high_sym, cond, _ in sym.ranges:
         if expr_value(cond):
             low_s = low_sym.str_value
             high_s = high_sym.str_value
@@ -1883,8 +1883,8 @@ def _range_info(sym):
     # Returns a string with information about the valid range for the symbol
     # 'sym', or None if 'sym' doesn't have a range
 
-    if sym.type in (INT, HEX):
-        for low, high, cond in sym.ranges:
+    if sym.orig_type in (INT, HEX):
+        for low, high, cond, _ in sym.ranges:
             if expr_value(cond):
                 return "Range: {}-{}".format(low.str_value, high.str_value)
 

--- a/menuconfig.py
+++ b/menuconfig.py
@@ -4104,7 +4104,7 @@ def _check_valid(sym, s):
         _error("'{}' is a malformed {} value".format(s, TYPE_TO_STR[sym.orig_type]))
         return False
 
-    for low_sym, high_sym, cond in sym.ranges:
+    for low_sym, high_sym, cond, _ in sym.ranges:
         if expr_value(cond):
             low_s = low_sym.str_value
             high_s = high_sym.str_value
@@ -4123,7 +4123,7 @@ def _range_info(sym):
     # 'sym', or None if 'sym' doesn't have a range
 
     if sym.orig_type in (INT, HEX):
-        for low, high, cond in sym.ranges:
+        for low, high, cond, _ in sym.ranges:
             if expr_value(cond):
                 return "Range: {}-{}".format(low.str_value, high.str_value)
 


### PR DESCRIPTION
The Symbol.ranges attribute in kconfiglib returns 4-tuples (low, high, cond, loc), but menuconfig and guiconfig were using the old 3-tuple unpacking pattern, causing ValueError when processing integer/hex symbols with range properties.

Changes:
- Update all sym.ranges unpacking to handle 4-tuple format
- Use underscore (_) for unused location parameter to indicate intent
- Standardize on sym.orig_type instead of sym.type for consistency with kconfiglib internals and to avoid potential issues with type transformations

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix crashes in menuconfig and guiconfig when handling INT/HEX symbol ranges by aligning with kconfiglib’s current API. Users can now enter values without ValueError.

- **Bug Fixes**
  - Unpack sym.ranges as (low, high, cond, _) to match the 4-tuple format and prevent ValueError.
  - Use sym.orig_type for INT/HEX validation and range display to stay consistent with kconfiglib.

<!-- End of auto-generated description by cubic. -->

