### PR TITLE
CI: Bump action and black versions

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -36,7 +36,7 @@ jobs:
         pip install --user setuptools wheel
 
     - name: Check out Kconfiglib source code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     - name: Build source distribution
       run: |
@@ -47,7 +47,7 @@ jobs:
         python setup.py bdist_wheel
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: dist
         path: dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
     - name: Download build artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
 
     - name: Upload release assets
       uses: softprops/action-gh-release@v2

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
     - name: Check out Kconfiglib source code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     - name: Set up Python
       uses: actions/setup-python@v6
@@ -23,7 +23,7 @@ jobs:
     - name: Install tools
       run: |
            sudo apt-get install -q=2 shfmt python3-pip
-           pip3 install black==25.9.0
+           pip3 install black==26.1.0
 
     - name: Run format check
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
     - name: Check out Linux source code
       # Skip for Windows (headless-only mode)
       if: ${{ matrix.target.headless-only != true }}
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
       # On Windows, checkout of 'aux.c' is expected to fail because ... Windows.
       continue-on-error: true
       with:
@@ -70,7 +70,7 @@ jobs:
         ref: v5.4
 
     - name: Check out Kconfiglib source code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
       with:
         # Windows (headless-only): checkout to root directory
         # Linux/macOS (full test): checkout to Kconfiglib subdirectory

--- a/examples/defconfig_oldconfig.py
+++ b/examples/defconfig_oldconfig.py
@@ -16,7 +16,6 @@ import sys
 
 import kconfiglib
 
-
 kconf = kconfiglib.Kconfig(sys.argv[1])
 
 # Mirrors defconfig

--- a/examples/dumpvars.py
+++ b/examples/dumpvars.py
@@ -10,7 +10,6 @@ import sys
 
 import kconfiglib
 
-
 print(
     " ".join(
         "{}='{}'".format(var, os.environ[var])

--- a/examples/eval_expr.py
+++ b/examples/eval_expr.py
@@ -10,7 +10,6 @@ import sys
 
 import kconfiglib
 
-
 if len(sys.argv) < 3:
     sys.exit("Pass the expression to evaluate with SCRIPT_ARG=<expression>")
 

--- a/examples/find_symbol.py
+++ b/examples/find_symbol.py
@@ -78,7 +78,6 @@ import sys
 
 import kconfiglib
 
-
 if len(sys.argv) < 3:
     sys.exit('Pass symbol name (without "CONFIG_" prefix) with SCRIPT_ARG=<name>')
 

--- a/examples/help_grep.py
+++ b/examples/help_grep.py
@@ -38,7 +38,6 @@ import sys
 
 from kconfiglib import Kconfig, Symbol, Choice, MENU, COMMENT
 
-
 if len(sys.argv) < 3:
     sys.exit("Pass the regex with SCRIPT_ARG=<regex>")
 

--- a/examples/list_undefined.py
+++ b/examples/list_undefined.py
@@ -41,7 +41,6 @@ import subprocess
 
 from kconfiglib import Kconfig
 
-
 # Referenced inside the Kconfig files
 os.environ["KERNELVERSION"] = str(
     subprocess.check_output(("make", "kernelversion")).decode("utf-8").rstrip()

--- a/examples/menuconfig_example.py
+++ b/examples/menuconfig_example.py
@@ -138,7 +138,6 @@ from kconfiglib import (
     TRI_TO_STR,
 )
 
-
 # Python 2/3 compatibility hack
 if sys.version_info[0] < 3:
     input = raw_input

--- a/examples/merge_config.py
+++ b/examples/merge_config.py
@@ -75,7 +75,6 @@ import sys
 
 from kconfiglib import Kconfig, BOOL, TRISTATE, TRI_TO_STR
 
-
 if len(sys.argv) < 4:
     sys.exit("usage: merge_config.py Kconfig merged_config config1 [config2 ...]")
 

--- a/examples/print_config_tree.py
+++ b/examples/print_config_tree.py
@@ -67,7 +67,6 @@ from kconfiglib import (
     expr_value,
 )
 
-
 # Add help description to output
 WITH_HELP_DESC = False
 

--- a/examples/print_sym_info.py
+++ b/examples/print_sym_info.py
@@ -37,7 +37,6 @@ import sys
 
 from kconfiglib import Kconfig, TRI_TO_STR
 
-
 if len(sys.argv) < 3:
     sys.exit('Pass symbol name (without "CONFIG_" prefix) with SCRIPT_ARG=<name>')
 

--- a/genconfig.py
+++ b/genconfig.py
@@ -79,9 +79,7 @@ information isn't needed.
 Enable generation of symbol dependency information for incremental builds,
 optionally specifying the output directory (default: {}). See the docstring of
 Kconfig.sync_deps() in Kconfiglib for more information.
-""".format(
-            DEFAULT_SYNC_DEPS_PATH
-        ),
+""".format(DEFAULT_SYNC_DEPS_PATH),
     )
 
     parser.add_argument(

--- a/lint.py
+++ b/lint.py
@@ -120,17 +120,13 @@ def run(cmd, cwd=None, check=True):
     stdout = stdout.decode("utf-8", errors="ignore")
     stderr = stderr.decode("utf-8")
     if check and process.returncode:
-        err(
-            """\
+        err("""\
 '{}' exited with status {}.
 
 ===stdout===
 {}
 ===stderr===
-{}""".format(
-                cmd_s, process.returncode, stdout, stderr
-            )
-        )
+{}""".format(cmd_s, process.returncode, stdout, stderr))
 
     if stderr:
         warn("'{}' wrote to stderr:\n{}".format(cmd_s, stderr))

--- a/menuconfig.py
+++ b/menuconfig.py
@@ -260,20 +260,12 @@ _MAIN_HELP_LINES = """
 [O] Load                    [?] Symbol info            [/] Jump to symbol
 [F] Toggle show-help mode   [C] Toggle show-name mode  [A] Toggle show-all mode
 [Q] Quit (prompts for save) [D] Save minimal config (advanced)
-"""[
-    1:-1
-].split(
-    "\n"
-)
+"""[1:-1].split("\n")
 
 # Lines of help text shown at the bottom of the information dialog
 _INFO_HELP_LINES = """
 [ESC/q] Return to menu      [/] Jump to symbol
-"""[
-    1:-1
-].split(
-    "\n"
-)
+"""[1:-1].split("\n")
 
 # Lines of help text shown at the bottom of the search dialog
 _JUMP_TO_HELP_LINES = """
@@ -282,11 +274,7 @@ module). The up/down cursor keys step in the list. [Enter] jumps to the
 selected symbol. [ESC] aborts the search. Type multiple space-separated
 strings/regexes to find entries that match all of them. Type Ctrl-F to
 view the help of the selected item without leaving the dialog.
-"""[
-    1:-1
-].split(
-    "\n"
-)
+"""[1:-1].split("\n")
 
 #
 # Styling
@@ -705,8 +693,7 @@ def _ensure_curses():
     except ImportError as e:
         if not _IS_WINDOWS:
             raise
-        sys.exit(
-            """\
+        sys.exit("""\
 menuconfig failed to import the standard Python 'curses' library. Try
 installing a package like windows-curses
 (https://github.com/zephyrproject-rtos/windows-curses) by running this command
@@ -719,10 +706,7 @@ installed when installing Kconfiglib via pip on Windows (because it breaks
 installation on MSYS2).
 
 Exception:
-{}: {}""".format(
-                type(e).__name__, e
-            )
-        )
+{}: {}""".format(type(e).__name__, e))
 
 
 def _main():

--- a/testsuite.py
+++ b/testsuite.py
@@ -1364,9 +1364,7 @@ tests/Krecursive2:1: recursive 'source' of 'tests/Krecursive1' detected. Check t
 Include path:
 tests/Krecursive1:1
 tests/Krecursive2:1
-"""[
-                    :-1
-                ],
+"""[:-1],
             )
         except:
             fail("recursive 'source' raised wrong exception")
@@ -2334,9 +2332,7 @@ tests/Krecursive2:1
 #define CONFIG_I 5
 #define CONFIG_N 6
 #define CONFIG_G 7
-"""[
-            1:
-        ],
+"""[1:],
     )
 
     # Differs from defaults
@@ -2356,9 +2352,7 @@ CONFIG_E=-1
 CONFIG_R2=-1
 CONFIG_N=-1
 CONFIG_G=-1
-"""[
-            1:
-        ],
+"""[1:],
     )
 
     # Test header strings in configuration files and headers
@@ -2880,9 +2874,7 @@ config J
 	depends on A
 
 ...depends again on A (defined at Kconfiglib/tests/Kdeploop10:1)
-"""[
-                :-1
-            ],
+"""[:-1],
         )
     except:
         fail("Loop detection message check raised wrong exception")
@@ -3185,9 +3177,7 @@ warning: undefined symbol UNDEF_3:
 menu "menu"
 	depends on UNDEF_1
 	visible if UNDEF_3
-"""[
-                1:-1
-            ],
+"""[1:-1],
         )
 
         os.environ.pop("KCONFIG_WARN_UNDEF")


### PR DESCRIPTION
This bumps actions/checkout to v6, actions/upload-artifact to v6, actions/download-artifact to v7, and black to 26.1.0. Reformat all tracked Python files with the updated formatter.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade CI workflows to newer GitHub Actions and bump Black to 26.1.0; reformatted Python files accordingly. This keeps CI current and ensures consistent formatting.

- **Dependencies**
  - actions/checkout: v6 (was v5)
  - actions/upload-artifact: v6 (was v4)
  - actions/download-artifact: v7 (was v4)
  - black: 26.1.0 (was 25.9.0)

- **Refactors**
  - Reformat all tracked Python files with Black 26.1.0 (formatting-only changes).

<sup>Written for commit b925e01b5c5e8bf7ff621fe9688b8974f0610ffb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

