### PR TITLE
Harden security

### DIFF
--- a/guiconfig.py
+++ b/guiconfig.py
@@ -99,6 +99,8 @@ from kconfiglib import (
     TYPE_TO_STR,
     standard_kconfig,
     standard_config_filename,
+    _needs_save as _kconf_needs_save,
+    _extract_controlling_symbols,
 )
 
 # If True, use GIF image data embedded in this file instead of separate GIF
@@ -462,28 +464,7 @@ def _load_config():
 
 
 def _needs_save():
-    # Returns True if a just-loaded .config file is outdated (would get
-    # modified when saving)
-
-    if _kconf.missing_syms:
-        # Assignments to undefined symbols in the .config
-        return True
-
-    for sym in _kconf.unique_defined_syms:
-        if sym.user_value is None:
-            if sym.config_string:
-                # Unwritten symbol
-                return True
-        elif sym.orig_type in (BOOL, TRISTATE):
-            if sym.tri_value != sym.user_value:
-                # Written bool/tristate symbol, new value
-                return True
-        elif sym.str_value != sym.user_value:
-            # Written string/int/hex symbol, new value
-            return True
-
-    # No need to prompt for save
-    return False
+    return _kconf_needs_save(_kconf)
 
 
 def _create_id_to_node():
@@ -1273,35 +1254,6 @@ def _get_force_info(sym):
         shown += ", +{}".format(len(sym_names) - 2)
 
     return " [{} {}]".format(prefix, shown)
-
-
-def _extract_controlling_symbols(expr_list):
-    # Extracts the primary controlling symbol from each expression string
-    # Returns a list of unique symbol names
-    #
-    # For "A && B", extracts "A" (the symbol doing the select/imply)
-    # For "A || B", extracts both "A" and "B"
-    # For simple "A", extracts "A"
-    #
-    # This avoids showing condition symbols as if they're doing the select/imply
-
-    sym_names = []
-    for expr in expr_list:
-        # Split on && first - we only want symbols before &&
-        # For "FOO && BAR", we want FOO (the selector), not BAR (the condition)
-        and_idx = expr.find(" && ")
-        primary = expr[:and_idx].strip() if and_idx != -1 else expr.strip()
-
-        # Now handle || - all parts are equal
-        if " || " in primary:
-            for part in primary.split(" || "):
-                part = part.strip()
-                if part and part not in sym_names:
-                    sym_names.append(part)
-        elif primary and primary not in sym_names:
-            sym_names.append(primary)
-
-    return sym_names
 
 
 def _node_str(node):


### PR DESCRIPTION
- Fix copy-paste bug in `_found_dep_loop`: use `weak_rev_dep` (not rev_dep) for imply-related dependency loop messages
- Escape `CONFIG_` prefix with re.escape() to prevent regex injection via the CONFIG_ environment variable
- Optimize `_check_undef_syms` from O(U*N*R) to O(N*R+U) using a reverse index, and replace string concatenation with "".join()
- Skip redundant list rebuilds in `_propagate_deps` when dep is y (common case for top-level symbols)
- Cache MenuNode.referenced as frozenset on first access; safe because menu node properties are immutable after parsing
- Extract duplicated `_needs_save` and `_extract_controlling_symbols` from menuconfig/guiconfig into shared functions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened .config parsing to prevent regex injection, fixed imply-related loop messages, and sped up undefined symbol checks and dependency propagation. Also centralized save/controlling-symbol helpers for menuconfig and guiconfig and reduced menu node reference overhead.

- **Bug Fixes**
  - Escaped CONFIG_ prefix in .config regex to prevent injection via the CONFIG_ environment variable.
  - Used weak_rev_dep in _found_dep_loop for correct imply-related loop messages.

- **Refactors**
  - Optimized _check_undef_syms from O(U*N*R) to O(N*R+U) with a reverse index and joined message assembly.
  - Skipped list rebuilds in _propagate_deps when dep is y.
  - Cached MenuNode.referenced as a frozenset after first access.
  - Moved _needs_save and _extract_controlling_symbols into shared helpers used by menuconfig and guiconfig.

<sup>Written for commit 04afc06493a6e04005f400bc82457e26e51cfbb7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

