### PR TITLE
Add dual-prompt visibility tests

### DIFF
--- a/tests/Kdual_prompt
+++ b/tests/Kdual_prompt
@@ -1,0 +1,23 @@
+config MODULES
+    bool
+    default y
+
+config BAR
+    bool "BAR"
+    default y
+
+config FOO
+    bool "Foo" if BAR
+
+config FOO
+    bool "Foo (EXPERIMENTAL)" if !BAR
+
+config TBAR
+    tristate "TBAR"
+    default m
+
+config TFOO
+    tristate "TFoo" if TBAR
+
+config TFOO
+    tristate "TFoo (EXPERIMENTAL)" if !TBAR


### PR DESCRIPTION
Bool-guarded dual prompts (if BAR / if !BAR) yield strict exclusivity. Tristate guards with m-state correctly show both prompts per C Kconfig NOT(m)=m semantics -- this is not a bug but inherent tristate logic.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests to verify dual-prompt visibility for symbols defined under opposing guards. Confirms bool guards are strictly exclusive and that tristate guards show both prompts at m (NOT(m)=m), matching C Kconfig semantics.

<sup>Written for commit a0c71d9603606a19e8157e2de2745234dc07d73b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

