### PR TITLE
Add Ruff linter with CI integration

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -23,10 +23,13 @@ jobs:
     - name: Install tools
       run: |
            sudo apt-get install -q=2 shfmt python3-pip
-           pip3 install black==26.1.0
+           pip3 install black==26.1.0 ruff==0.15.2
 
     - name: Run format check
       run: |
            .ci/check-newline.sh
            .ci/check-format.sh
       shell: bash
+
+    - name: Run Ruff linter
+      run: ruff check .

--- a/genconfig.py
+++ b/genconfig.py
@@ -74,11 +74,11 @@ information isn't needed.
         metavar="OUTPUT_DIR",
         nargs="?",
         const=DEFAULT_SYNC_DEPS_PATH,
-        help="""
+        help=f"""
 Enable generation of symbol dependency information for incremental builds,
-optionally specifying the output directory (default: {}). See the docstring of
+optionally specifying the output directory (default: {DEFAULT_SYNC_DEPS_PATH}). See the docstring of
 Kconfig.sync_deps() in Kconfiglib for more information.
-""".format(DEFAULT_SYNC_DEPS_PATH),
+""",
     )
 
     parser.add_argument(

--- a/kconfiglib.py
+++ b/kconfiglib.py
@@ -571,7 +571,7 @@ VERSION = (14, 1, 0)
 #
 
 
-class Kconfig(object):
+class Kconfig:
     """
     Represents a Kconfig configuration, e.g. for x86 or ARM. This is the set of
     symbols, choices, and menu nodes appearing in the configuration. Creating
@@ -930,7 +930,7 @@ class Kconfig(object):
           Related PEP: https://www.python.org/dev/peps/pep-0538/
 
         suppress_traceback (default: False):
-          Helper for tools. When True, any EnvironmentError or KconfigError
+          Helper for tools. When True, any OSError or KconfigError
           generated during parsing is caught, the exception message is printed
           to stderr together with the command name, and sys.exit(1) is called
           (which generates SystemExit).
@@ -938,7 +938,7 @@ class Kconfig(object):
           This hides the Python traceback for "expected" errors like syntax
           errors in Kconfig files.
 
-          Other exceptions besides EnvironmentError and KconfigError are still
+          Other exceptions besides OSError and KconfigError are still
           propagated when suppress_traceback is True.
 
         search_paths (default: None):
@@ -975,7 +975,7 @@ class Kconfig(object):
                 search_paths,
                 allow_empty_macros,
             )
-        except (EnvironmentError, KconfigError) as e:
+        except (OSError, KconfigError) as e:
             if suppress_traceback:
                 cmd = sys.argv[0]  # Empty string if missing
                 if cmd:
@@ -1015,7 +1015,7 @@ class Kconfig(object):
         # Escape the prefix to prevent regex injection via CONFIG_ env var.
         escaped_prefix = re.escape(self.config_prefix)
         self._set_match = _re_match(escaped_prefix + r"([^=]+)=(.*)")
-        self._unset_match = _re_match(r"# {}([^ ]+) is not set".format(escaped_prefix))
+        self._unset_match = _re_match(rf"# {escaped_prefix}([^ ]+) is not set")
 
         self.config_header = os.getenv("KCONFIG_CONFIG_HEADER", "")
         self.header_header = os.getenv("KCONFIG_AUTOHEADER_HEADER", "")
@@ -1184,7 +1184,7 @@ class Kconfig(object):
                     try:
                         with self._open_config(filename.str_value) as f:
                             return f.name
-                    except EnvironmentError:
+                    except OSError:
                         continue
 
         return None
@@ -1208,7 +1208,7 @@ class Kconfig(object):
         Kconfig.missing_syms as well.
 
         See the Kconfig.__init__() docstring for raised exceptions
-        (OSError/IOError). KconfigError is never raised here.
+        (OSError). KconfigError is never raised here.
 
         filename (default: None):
           Path to load configuration from (a string). Respects $srctree if set
@@ -1261,15 +1261,13 @@ class Kconfig(object):
             if not exists(filename) and not exists(join(self.srctree, filename)):
                 defconfig = self.defconfig_filename
                 if defconfig is None:
-                    return "Using default symbol values (no '{}')".format(filename)
+                    return f"Using default symbol values (no '{filename}')"
 
-                msg = " default configuration '{}' (no '{}')".format(
-                    defconfig, filename
-                )
+                msg = f" default configuration '{defconfig}' (no '{filename}')"
                 filename = defconfig
 
         if not msg:
-            msg = " configuration '{}'".format(filename)
+            msg = f" configuration '{filename}'"
 
         # Disable the warning about assigning to symbols without prompts. This
         # is normal and expected within a .config file.
@@ -1331,10 +1329,8 @@ class Kconfig(object):
                             and val.startswith(("y", "m", "n"))
                         ):
                             self._warn(
-                                "'{}' is not a valid value for the {} "
-                                "symbol {}. Assignment ignored.".format(
-                                    val, TYPE_TO_STR[sym.orig_type], sym.name_and_loc
-                                ),
+                                f"'{val}' is not a valid value for the {TYPE_TO_STR[sym.orig_type]} "
+                                f"symbol {sym.name_and_loc}. Assignment ignored.",
                                 loc,
                             )
                             continue
@@ -1363,9 +1359,7 @@ class Kconfig(object):
                         if not match:
                             self._warn(
                                 "malformed string literal in "
-                                "assignment to {}. Assignment ignored.".format(
-                                    sym.name_and_loc
-                                ),
+                                f"assignment to {sym.name_and_loc}. Assignment ignored.",
                                 loc,
                             )
                             continue
@@ -1380,7 +1374,7 @@ class Kconfig(object):
                         # lines or comments. 'line' has already been
                         # rstrip()'d, so blank lines show up as "" here.
                         if line and not line.lstrip().startswith("#"):
-                            self._warn("ignoring malformed line '{}'".format(line), loc)
+                            self._warn(f"ignoring malformed line '{line}'", loc)
 
                         continue
 
@@ -1420,9 +1414,7 @@ class Kconfig(object):
         self.missing_syms.append((name, val))
         if self.warn_assign_undef:
             self._warn(
-                "attempt to assign the value '{}' to the undefined symbol {}".format(
-                    val, name
-                ),
+                f"attempt to assign the value '{val}' to the undefined symbol {name}",
                 loc,
             )
 
@@ -1435,9 +1427,7 @@ class Kconfig(object):
         else:
             user_val = sym.user_value
 
-        msg = '{} set more than once. Old value "{}", new value "{}".'.format(
-            sym.name_and_loc, user_val, new_val
-        )
+        msg = f'{sym.name_and_loc} set more than once. Old value "{user_val}", new value "{new_val}".'
 
         if user_val == new_val:
             if self.warn_assign_redun:
@@ -1470,13 +1460,9 @@ class Kconfig(object):
             return
 
         def std_msg(e):
-            # "Upcasts" a _KconfigIOError to an IOError, removing the custom
+            # "Upcasts" a _KconfigIOError to an OSError, removing the custom
             # __str__() message. The standard message is better here.
-            #
-            # This might also convert an OSError to an IOError in obscure
-            # cases, but it's probably not a big deal. The distinction is
-            # shaky (see PEP-3151).
-            return IOError(e.errno, e.strerror, e.filename)
+            return OSError(e.errno, e.strerror, e.filename)
 
         old_warn_assign_override = self.warn_assign_override
         old_warn_assign_redun = self.warn_assign_redun
@@ -1485,23 +1471,21 @@ class Kconfig(object):
         if allconfig in ("", "1"):
             try:
                 print(self.load_config(filename, False))
-            except EnvironmentError as e1:
+            except OSError as e1:
                 try:
                     print(self.load_config("all.config", False))
-                except EnvironmentError as e2:
+                except OSError as e2:
                     sys.exit(
-                        "error: KCONFIG_ALLCONFIG is set, but neither {} "
-                        "nor all.config could be opened: {}, {}".format(
-                            filename, std_msg(e1), std_msg(e2)
-                        )
+                        f"error: KCONFIG_ALLCONFIG is set, but neither {filename} "
+                        f"nor all.config could be opened: {std_msg(e1)}, {std_msg(e2)}"
                     )
         else:
             try:
                 print(self.load_config(allconfig, False))
-            except EnvironmentError as e:
+            except OSError as e:
                 sys.exit(
-                    "error: KCONFIG_ALLCONFIG is set to '{}', which "
-                    "could not be opened: {}".format(allconfig, std_msg(e))
+                    f"error: KCONFIG_ALLCONFIG is set to '{allconfig}', which "
+                    f"could not be opened: {std_msg(e)}"
                 )
 
         self.warn_assign_override = old_warn_assign_override
@@ -1546,8 +1530,8 @@ class Kconfig(object):
             filename = os.getenv("KCONFIG_AUTOHEADER", "include/generated/autoconf.h")
 
         if self._write_if_changed(filename, self._autoconf_contents(header)):
-            return "Kconfig header saved to '{}'".format(filename)
-        return "No change to Kconfig header in '{}'".format(filename)
+            return f"Kconfig header saved to '{filename}'"
+        return f"No change to Kconfig header in '{filename}'"
 
     def _autoconf_contents(self, header):
         # write_autoconf() helper. Returns the contents to write as a string,
@@ -1572,22 +1556,18 @@ class Kconfig(object):
 
             if sym.orig_type in _BOOL_TRISTATE:
                 if val == "y":
-                    add("#define {}{} 1\n".format(self.config_prefix, sym.name))
+                    add(f"#define {self.config_prefix}{sym.name} 1\n")
                 elif val == "m":
-                    add("#define {}{}_MODULE 1\n".format(self.config_prefix, sym.name))
+                    add(f"#define {self.config_prefix}{sym.name}_MODULE 1\n")
 
             elif sym.orig_type is STRING:
-                add(
-                    '#define {}{} "{}"\n'.format(
-                        self.config_prefix, sym.name, escape(val)
-                    )
-                )
+                add(f'#define {self.config_prefix}{sym.name} "{escape(val)}"\n')
 
             else:  # sym.orig_type in _INT_HEX:
                 if sym.orig_type is HEX and not val.startswith(("0x", "0X")):
                     val = "0x" + val
 
-                add("#define {}{} {}\n".format(self.config_prefix, sym.name, val))
+                add(f"#define {self.config_prefix}{sym.name} {val}\n")
 
         return "".join(chunks)
 
@@ -1610,7 +1590,7 @@ class Kconfig(object):
         build tools.
 
         See the Kconfig.__init__() docstring for raised exceptions
-        (OSError/IOError). KconfigError is never raised here.
+        (OSError). KconfigError is never raised here.
 
         filename (default: None):
           Path to write configuration to (a string).
@@ -1660,7 +1640,7 @@ class Kconfig(object):
 
         contents = self._config_contents(header)
         if self._contents_eq(filename, contents):
-            return "No change to configuration in '{}'".format(filename)
+            return f"No change to configuration in '{filename}'"
 
         if save_old:
             _save_old(filename)
@@ -1668,7 +1648,7 @@ class Kconfig(object):
         with self._open(filename, "w") as f:
             f.write(contents)
 
-        return "Configuration saved to '{}'".format(filename)
+        return f"Configuration saved to '{filename}'"
 
     def _config_contents(self, header):
         # write_config() helper. Returns the contents to write as a string,
@@ -1711,7 +1691,7 @@ class Kconfig(object):
                         and expr_value(node.visibility)
                         and node is not self.top_node
                     ):
-                        add("# end of {}\n".format(node.prompt[0]))
+                        add(f"# end of {node.prompt[0]}\n")
                         after_end_comment = True
 
                     if node.next:
@@ -1745,7 +1725,7 @@ class Kconfig(object):
                 (item is MENU and expr_value(node.visibility)) or item is COMMENT
             ):
 
-                add("\n#\n# {}\n#\n".format(node.prompt[0]))
+                add(f"\n#\n# {node.prompt[0]}\n#\n")
                 after_end_comment = False
 
                 # Empty menus (no children) still need an "end of" comment
@@ -1753,7 +1733,7 @@ class Kconfig(object):
                 # ascending back up from children, but that never happens
                 # for a childless menu.
                 if item is MENU and not node.list:
-                    add("# end of {}\n".format(node.prompt[0]))
+                    add(f"# end of {node.prompt[0]}\n")
                     after_end_comment = True
 
     def write_min_config(self, filename, header=None):
@@ -1769,7 +1749,7 @@ class Kconfig(object):
         are merged or edited by hand.
 
         See the Kconfig.__init__() docstring for raised exceptions
-        (OSError/IOError). KconfigError is never raised here.
+        (OSError). KconfigError is never raised here.
 
         filename:
           Path to write minimal configuration to.
@@ -1790,8 +1770,8 @@ class Kconfig(object):
         print(kconf.write_min_config()).
         """
         if self._write_if_changed(filename, self._min_config_contents(header)):
-            return "Minimal configuration saved to '{}'".format(filename)
-        return "No change to minimal configuration in '{}'".format(filename)
+            return f"Minimal configuration saved to '{filename}'"
+        return f"No change to minimal configuration in '{filename}'"
 
     def _min_config_contents(self, header):
         # write_min_config() helper. Returns the contents to write as a string,
@@ -1841,7 +1821,7 @@ class Kconfig(object):
         compiling source files that depend on configuration symbols.
 
         See the Kconfig.__init__() docstring for raised exceptions
-        (OSError/IOError). KconfigError is never raised here.
+        (OSError). KconfigError is never raised here.
 
         path:
           Path to directory
@@ -1955,7 +1935,7 @@ class Kconfig(object):
 
         try:
             auto_conf = self._open(join(path, "auto.conf"), "r")
-        except EnvironmentError as e:
+        except OSError as e:
             if e.errno == errno.ENOENT:
                 # No old values
                 return
@@ -2126,14 +2106,14 @@ class Kconfig(object):
         return "<{}>".format(
             ", ".join(
                 (
-                    "configuration with {} symbols".format(len(self.syms)),
-                    'main menu prompt "{}"'.format(self.mainmenu_text),
+                    f"configuration with {len(self.syms)} symbols",
+                    f'main menu prompt "{self.mainmenu_text}"',
                     (
                         "srctree is current directory"
                         if not self.srctree
-                        else 'srctree "{}"'.format(self.srctree)
+                        else f'srctree "{self.srctree}"'
                     ),
-                    'config symbol prefix "{}"'.format(self.config_prefix),
+                    f'config symbol prefix "{self.config_prefix}"',
                     "warnings " + status(self.warn),
                     "printing of warnings to stderr " + status(self.warn_to_stderr),
                     "undef. symbol assignment warnings "
@@ -2161,32 +2141,28 @@ class Kconfig(object):
 
         try:
             return self._open(filename, "r")
-        except EnvironmentError as e:
+        except OSError as e:  # noqa: F841
             # This will try opening the same file twice if $srctree is unset,
             # but it's not a big deal
             try:
                 return self._open(join(self.srctree, filename), "r")
-            except EnvironmentError as e2:
+            except OSError as e2:
                 # This is needed for Python 3, because e2 is deleted after
                 # the try block:
                 #
                 # https://docs.python.org/3/reference/compound_stmts.html#the-try-statement
                 e = e2
 
+            srctree_status = (
+                f"set to '{self.srctree}'" if self.srctree else "unset or blank"
+            )
             raise _KconfigIOError(
                 e,
-                "Could not open '{}' ({}: {}). Check that the $srctree "
-                "environment variable ({}) is set correctly.".format(
-                    filename,
-                    errno.errorcode[e.errno],
-                    e.strerror,
-                    (
-                        "set to '{}'".format(self.srctree)
-                        if self.srctree
-                        else "unset or blank"
-                    ),
-                ),
-            )
+                f"Could not open '{filename}' "
+                f"({errno.errorcode[e.errno]}: {e.strerror}). "
+                f"Check that the $srctree environment variable "
+                f"({srctree_status}) is set correctly.",
+            ) from e
 
     def _enter_file(self, filename):
         # Jumps to the beginning of a sourced Kconfig file, saving the previous
@@ -2239,27 +2215,19 @@ class Kconfig(object):
                         self.linenr,
                         rel_filename,
                         "\n".join(
-                            "{}:{}".format(name, linenr)
-                            for name, linenr in self._include_path
+                            f"{name}:{linenr}" for name, linenr in self._include_path
                         ),
                     )
                 )
 
         try:
             self._readline = self._open(filename, "r").readline
-        except EnvironmentError as e:
+        except OSError as e:
             # We already know that the file exists
             raise _KconfigIOError(
                 e,
-                "{}:{}: Could not open '{}' (in '{}') ({}: {})".format(
-                    self.filename,
-                    self.linenr,
-                    filename,
-                    self._line.strip(),
-                    errno.errorcode[e.errno],
-                    e.strerror,
-                ),
-            )
+                f"{self.filename}:{self.linenr}: Could not open '{filename}' (in '{self._line.strip()}') ({errno.errorcode[e.errno]}: {e.strerror})",
+            ) from e
 
         self.filename = rel_filename
         self.linenr = 0
@@ -2354,7 +2322,7 @@ class Kconfig(object):
                 # Robust re. things like encoding and line endings (mmap()
                 # trickery isn't)
                 return f.read(len(contents) + 1) == contents
-        except EnvironmentError:
+        except OSError:
             # If the error here would prevent writing the file as well, we'll
             # notice it later
             return False
@@ -2380,7 +2348,7 @@ class Kconfig(object):
         if self._parsing_kconfigs:
             self.syms[name] = sym
         else:
-            self._warn("no symbol {} in configuration".format(name))
+            self._warn(f"no symbol {name} in configuration")
 
         return sym
 
@@ -2487,9 +2455,7 @@ class Kconfig(object):
 
                     if token is not _T_CHOICE:
                         self._warn(
-                            "style: quotes recommended around '{}' in '{}'".format(
-                                name, self._line.strip()
-                            ),
+                            f"style: quotes recommended around '{name}' in '{self._line.strip()}'",
                             self.loc,
                         )
 
@@ -2879,15 +2845,15 @@ class Kconfig(object):
                 # Plain variable
                 if var._n_expansions:
                     self._parse_error(
-                        "Preprocessor variable {} recursively "
-                        "references itself".format(var.name)
+                        f"Preprocessor variable {var.name} recursively "
+                        "references itself"
                     )
             elif var._n_expansions > 100:
                 # Allow functions to call themselves, but guess that functions
                 # that are overly recursive are stuck
                 self._parse_error(
-                    "Preprocessor function {} seems stuck "
-                    "in infinite recursion".format(var.name)
+                    f"Preprocessor function {var.name} seems stuck "
+                    "in infinite recursion"
                 )
 
             var._n_expansions += 1
@@ -2907,15 +2873,13 @@ class Kconfig(object):
                 if min_arg == max_arg:
                     expected_args = min_arg
                 elif max_arg is None:
-                    expected_args = "{} or more".format(min_arg)
+                    expected_args = f"{min_arg} or more"
                 else:
-                    expected_args = "{}-{}".format(min_arg, max_arg)
+                    expected_args = f"{min_arg}-{max_arg}"
 
                 raise KconfigError(
-                    "{}:{}: bad number of arguments in call "
-                    "to {}, expected {}, got {}".format(
-                        self.filename, self.linenr, fn, expected_args, len(args) - 1
-                    )
+                    f"{self.filename}:{self.linenr}: bad number of arguments in call "
+                    f"to {fn}, expected {expected_args}, got {len(args) - 1}"
                 )
 
             return py_fn(self, *args)
@@ -3012,9 +2976,7 @@ class Kconfig(object):
 
                 if node.is_menuconfig and not node.prompt:
                     self._warn(
-                        "the menuconfig symbol {} has no prompt".format(
-                            sym.name_and_loc
-                        )
+                        f"the menuconfig symbol {sym.name_and_loc} has no prompt"
                     )
 
                 # Equivalent to
@@ -3060,7 +3022,7 @@ class Kconfig(object):
                             pattern,
                             self._line.strip(),
                             (
-                                "set to '{}'".format(self.srctree)
+                                f"set to '{self.srctree}'"
                                 if self.srctree
                                 else "unset or blank"
                             ),
@@ -3190,7 +3152,7 @@ class Kconfig(object):
             else:
                 end_str = "endmenu"
             raise KconfigError(
-                "error: expected '{}' at end of '{}'".format(end_str, self.filename)
+                f"error: expected '{end_str}' at end of '{self.filename}'"
             )
 
         return prev
@@ -3326,14 +3288,13 @@ class Kconfig(object):
                             (
                                 self._lookup_const_sym(os.environ[env_var]),
                                 self.y,
-                                "env[{}]".format(env_var),
+                                f"env[{env_var}]",
                             )
                         )
                     else:
                         self._warn(
-                            "{1} has 'option env=\"{0}\"', "
-                            "but the environment variable {0} is not "
-                            "set".format(node.item.name, env_var),
+                            f"{node.item.name} has 'option env=\"{env_var}\"', "
+                            f"but the environment variable {env_var} is not set",
                             self.loc,
                         )
 
@@ -3343,10 +3304,8 @@ class Kconfig(object):
                             "in strings directly, meaning you do not "
                             "need 'option env=...' \"bounce\" symbols. "
                             "For compatibility with the C tools, "
-                            "rename {} to {} (so that the symbol name "
-                            "matches the environment variable name).".format(
-                                node.item.name, env_var
-                            ),
+                            f"rename {node.item.name} to {env_var} (so that the symbol name "
+                            "matches the environment variable name).",
                             self.loc,
                         )
 
@@ -3356,8 +3315,8 @@ class Kconfig(object):
                     else:
                         self._warn(
                             "'option defconfig_list' set on multiple "
-                            "symbols ({0} and {1}). Only {0} will be "
-                            "used.".format(self.defconfig_list.name, node.item.name),
+                            f"symbols ({self.defconfig_list.name} and {node.item.name}). Only {self.defconfig_list.name} will be "
+                            "used.",
                             self.loc,
                         )
 
@@ -3428,9 +3387,7 @@ class Kconfig(object):
         # UNKNOWN is falsy
         if sc.orig_type and sc.orig_type is not new_type:
             self._warn(
-                "{} defined with multiple types, {} will be used".format(
-                    sc.name_and_loc, TYPE_TO_STR[new_type]
-                )
+                f"{sc.name_and_loc} defined with multiple types, {TYPE_TO_STR[new_type]} will be used"
             )
 
         sc.orig_type = new_type
@@ -3921,25 +3878,16 @@ class Kconfig(object):
                     for target_sym, _, _ in rel:
                         if target_sym.orig_type not in _BOOL_TRISTATE_UNKNOWN:
                             self._warn(
-                                "{} {} the {} symbol {}, which is not "
-                                "bool or tristate".format(
-                                    sym.name_and_loc,
-                                    rel_name,
-                                    TYPE_TO_STR[target_sym.orig_type],
-                                    target_sym.name_and_loc,
-                                )
+                                f"{sym.name_and_loc} {rel_name} the {TYPE_TO_STR[target_sym.orig_type]} symbol {target_sym.name_and_loc}, which is not "
+                                "bool or tristate"
                             )
 
             elif sym.orig_type:  # STRING/INT/HEX
                 for default, _, _ in sym.defaults:
                     if default.__class__ is not Symbol:
                         raise KconfigError(
-                            "the {} symbol {} has a malformed default {} -- "
-                            "expected a single symbol".format(
-                                TYPE_TO_STR[sym.orig_type],
-                                sym.name_and_loc,
-                                expr_str(default),
-                            )
+                            f"the {TYPE_TO_STR[sym.orig_type]} symbol {sym.name_and_loc} has a malformed default {expr_str(default)} -- "
+                            "expected a single symbol"
                         )
 
                     if sym.orig_type is STRING:
@@ -3959,29 +3907,21 @@ class Kconfig(object):
 
                     elif not num_ok(default, sym.orig_type):  # INT/HEX
                         self._warn(
-                            "the {0} symbol {1} has a non-{0} default {2}".format(
-                                TYPE_TO_STR[sym.orig_type],
-                                sym.name_and_loc,
-                                default.name_and_loc,
-                            )
+                            f"the {TYPE_TO_STR[sym.orig_type]} symbol {sym.name_and_loc} has a non-{TYPE_TO_STR[sym.orig_type]} default {default.name_and_loc}"
                         )
 
                 if sym.selects or sym.implies:
                     self._warn(
-                        "the {} symbol {} has selects or implies".format(
-                            TYPE_TO_STR[sym.orig_type], sym.name_and_loc
-                        )
+                        f"the {TYPE_TO_STR[sym.orig_type]} symbol {sym.name_and_loc} has selects or implies"
                     )
 
             else:  # UNKNOWN
-                self._warn("{} defined without a type".format(sym.name_and_loc))
+                self._warn(f"{sym.name_and_loc} defined without a type")
 
             if sym.ranges:
                 if sym.orig_type not in _INT_HEX:
                     self._warn(
-                        "the {} symbol {} has ranges, but is not int or hex".format(
-                            TYPE_TO_STR[sym.orig_type], sym.name_and_loc
-                        )
+                        f"the {TYPE_TO_STR[sym.orig_type]} symbol {sym.name_and_loc} has ranges, but is not int or hex"
                     )
                 else:
                     for low, high, _, _ in sym.ranges:
@@ -3990,13 +3930,8 @@ class Kconfig(object):
                         ):
 
                             self._warn(
-                                "the {0} symbol {1} has a non-{0} "
-                                "range [{2}, {3}]".format(
-                                    TYPE_TO_STR[sym.orig_type],
-                                    sym.name_and_loc,
-                                    low.name_and_loc,
-                                    high.name_and_loc,
-                                )
+                                f"the {TYPE_TO_STR[sym.orig_type]} symbol {sym.name_and_loc} has a non-{TYPE_TO_STR[sym.orig_type]} "
+                                f"range [{low.name_and_loc}, {high.name_and_loc}]"
                             )
 
     def _check_choice_sanity(self):
@@ -4005,10 +3940,8 @@ class Kconfig(object):
 
         def warn_select_imply(sym, expr, expr_type):
             msg = (
-                "the choice symbol {} is {} by the following symbols, but "
-                "select/imply has no effect on choice symbols".format(
-                    sym.name_and_loc, expr_type
-                )
+                f"the choice symbol {sym.name_and_loc} is {expr_type} by the following symbols, but "
+                "select/imply has no effect on choice symbols"
             )
 
             # si = select/imply
@@ -4020,9 +3953,7 @@ class Kconfig(object):
         for choice in self.unique_choices:
             if choice.orig_type not in _BOOL_TRISTATE:
                 self._warn(
-                    "{} defined with type {}".format(
-                        choice.name_and_loc, TYPE_TO_STR[choice.orig_type]
-                    )
+                    f"{choice.name_and_loc} defined with type {TYPE_TO_STR[choice.orig_type]}"
                 )
 
             for node in choice.nodes:
@@ -4034,25 +3965,21 @@ class Kconfig(object):
             for default, _, _ in choice.defaults:
                 if default.__class__ is not Symbol:
                     raise KconfigError(
-                        "{} has a malformed default {}".format(
-                            choice.name_and_loc, expr_str(default)
-                        )
+                        f"{choice.name_and_loc} has a malformed default {expr_str(default)}"
                     )
 
                 if default.choice is not choice:
                     self._warn(
-                        "the default selection {} of {} is not "
-                        "contained in the choice".format(
-                            default.name_and_loc, choice.name_and_loc
-                        )
+                        f"the default selection {default.name_and_loc} of {choice.name_and_loc} is not "
+                        "contained in the choice"
                     )
 
             for sym in choice.syms:
                 if sym.defaults:
                     self._warn(
-                        "default on the choice symbol {} will have "
+                        f"default on the choice symbol {sym.name_and_loc} will have "
                         "no effect, as defaults do not affect choice "
-                        "symbols".format(sym.name_and_loc)
+                        "symbols"
                     )
 
                 if sym.rev_dep is not sym.kconfig.n:
@@ -4065,25 +3992,19 @@ class Kconfig(object):
                     if node.parent.item is choice:
                         if not node.prompt:
                             self._warn(
-                                "the choice symbol {} has no prompt".format(
-                                    sym.name_and_loc
-                                )
+                                f"the choice symbol {sym.name_and_loc} has no prompt"
                             )
 
                     elif node.prompt:
                         self._warn(
-                            "the choice symbol {} is defined with a "
-                            "prompt outside the choice".format(sym.name_and_loc)
+                            f"the choice symbol {sym.name_and_loc} is defined with a "
+                            "prompt outside the choice"
                         )
 
     def _parse_error(self, msg):
         raise KconfigError(
             "{}error: couldn't parse '{}': {}".format(
-                (
-                    ""
-                    if self.filename is None
-                    else "{}:{}: ".format(self.filename, self.linenr)
-                ),
+                ("" if self.filename is None else f"{self.filename}:{self.linenr}: "),
                 self._line.strip(),
                 msg,
             )
@@ -4146,12 +4067,10 @@ class Kconfig(object):
             # - The MODULES symbol always exists
             if not sym.nodes and not is_num(sym.name) and sym.name != "MODULES":
 
-                parts = ["undefined symbol {}:".format(sym.name)]
+                parts = [f"undefined symbol {sym.name}:"]
                 for node in sym_to_nodes.get(sym, ()):
                     parts.append(
-                        "\n\n- Referenced at {}:{}:\n\n{}".format(
-                            node.loc[0], node.loc[1], node
-                        )
+                        f"\n\n- Referenced at {node.loc[0]}:{node.loc[1]}:\n\n{node}"
                     )
                 self._warn("".join(parts))
 
@@ -4163,14 +4082,14 @@ class Kconfig(object):
 
         msg = "warning: " + msg
         if loc is not None:
-            msg = "{}:{}: {}".format(loc[0], loc[1], msg)
+            msg = f"{loc[0]}:{loc[1]}: {msg}"
 
         self.warnings.append(msg)
         if self.warn_to_stderr:
             sys.stderr.write(msg + "\n")
 
 
-class Symbol(object):
+class Symbol:
     """
     Represents a configuration symbol:
 
@@ -4577,16 +4496,9 @@ class Symbol(object):
                     use_defaults = False
                     self._origin = _T_CONFIG, self.user_loc
                     self.kconfig._warn(
-                        "user value {} on the {} symbol {} clamped to {} due "
+                        f"user value {num2str(user_val)} on the {TYPE_TO_STR[self.orig_type]} symbol {self.name_and_loc} clamped to {num2str(clamp_to)} due "
                         "to being outside the active range "
-                        "([{}, {}])".format(
-                            num2str(user_val),
-                            TYPE_TO_STR[self.orig_type],
-                            self.name_and_loc,
-                            num2str(clamp_to),
-                            num2str(low),
-                            num2str(high),
-                        )
+                        f"([{num2str(low)}, {num2str(high)}])"
                     )
                 else:
                     # If the user value is well-formed and satisfies range
@@ -4638,14 +4550,8 @@ class Symbol(object):
                         if has_default:
                             num2str = str if base == 10 else hex
                             self.kconfig._warn(
-                                "default value {} on {} clamped to {} due to "
-                                "being outside the active range ([{}, {}])".format(
-                                    val_num,
-                                    self.name_and_loc,
-                                    num2str(clamp),
-                                    num2str(low),
-                                    num2str(high),
-                                )
+                                f"default value {val_num} on {self.name_and_loc} clamped to {num2str(clamp)} due to "
+                                f"being outside the active range ([{num2str(low)}, {num2str(high)}])"
                             )
 
         elif self.orig_type is STRING:
@@ -4685,10 +4591,8 @@ class Symbol(object):
             if self.orig_type:  # != UNKNOWN
                 # Would take some work to give the location here
                 self.kconfig._warn(
-                    "The {} symbol {} is being evaluated in a logical context "
-                    "somewhere. It will always evaluate to n.".format(
-                        TYPE_TO_STR[self.orig_type], self.name_and_loc
-                    )
+                    f"The {TYPE_TO_STR[self.orig_type]} symbol {self.name_and_loc} is being evaluated in a logical context "
+                    "somewhere. It will always evaluate to n."
                 )
 
             self._cached_tri_val = 0
@@ -4828,16 +4732,16 @@ class Symbol(object):
 
         if self.orig_type in _BOOL_TRISTATE:
             return (
-                "{}{}={}\n".format(self.kconfig.config_prefix, self.name, val)
+                f"{self.kconfig.config_prefix}{self.name}={val}\n"
                 if val != "n"
-                else "# {}{} is not set\n".format(self.kconfig.config_prefix, self.name)
+                else f"# {self.kconfig.config_prefix}{self.name} is not set\n"
             )
 
         if self.orig_type in _INT_HEX:
-            return "{}{}={}\n".format(self.kconfig.config_prefix, self.name, val)
+            return f"{self.kconfig.config_prefix}{self.name}={val}\n"
 
         # sym.orig_type is STRING
-        return '{}{}="{}"\n'.format(self.kconfig.config_prefix, self.name, escape(val))
+        return f'{self.kconfig.config_prefix}{self.name}="{escape(val)}"\n'
 
     @property
     def name_and_loc(self):
@@ -4924,7 +4828,7 @@ class Symbol(object):
             self.kconfig._warn(
                 "the value {} is invalid for {}, which has type {} -- "
                 "assignment ignored".format(
-                    TRI_TO_STR[value] if value in TRI_TO_STR else "'{}'".format(value),
+                    TRI_TO_STR[value] if value in TRI_TO_STR else f"'{value}'",
                     self.name_and_loc,
                     TYPE_TO_STR[self.orig_type],
                 )
@@ -5005,7 +4909,7 @@ class Symbol(object):
 
         for node in self.nodes:
             if node.prompt:
-                add('"{}"'.format(node.prompt[0]))
+                add(f'"{node.prompt[0]}"')
 
         # Only add quotes for non-bool/tristate symbols
         add(
@@ -5013,7 +4917,7 @@ class Symbol(object):
             + (
                 self.str_value
                 if self.orig_type in _BOOL_TRISTATE
-                else '"{}"'.format(self.str_value)
+                else f'"{self.str_value}"'
             )
         )
 
@@ -5027,7 +4931,7 @@ class Symbol(object):
                     + (
                         TRI_TO_STR[self.user_value]
                         if self.orig_type in _BOOL_TRISTATE
-                        else '"{}"'.format(self.user_value)
+                        else f'"{self.user_value}"'
                     )
                 )
 
@@ -5285,13 +5189,8 @@ class Symbol(object):
         # whose direct dependencies evaluate to m is selected to y.
 
         msg = (
-            "{} has direct dependencies {} with value {}, but is "
-            "currently being {}-selected by the following symbols:".format(
-                self.name_and_loc,
-                expr_str(self.direct_dep),
-                TRI_TO_STR[expr_value(self.direct_dep)],
-                TRI_TO_STR[expr_value(self.rev_dep)],
-            )
+            f"{self.name_and_loc} has direct dependencies {expr_str(self.direct_dep)} with value {TRI_TO_STR[expr_value(self.direct_dep)]}, but is "
+            f"currently being {TRI_TO_STR[expr_value(self.rev_dep)]}-selected by the following symbols:"
         )
 
         # The reverse dependencies from each select are ORed together
@@ -5307,24 +5206,17 @@ class Symbol(object):
             selecting_sym = split_expr(select, AND)[0]
 
             msg += (
-                "\n - {}, with value {}, direct dependencies {} "
-                "(value: {})".format(
-                    selecting_sym.name_and_loc,
-                    selecting_sym.str_value,
-                    expr_str(selecting_sym.direct_dep),
-                    TRI_TO_STR[expr_value(selecting_sym.direct_dep)],
-                )
+                f"\n - {selecting_sym.name_and_loc}, with value {selecting_sym.str_value}, direct dependencies {expr_str(selecting_sym.direct_dep)} "
+                f"(value: {TRI_TO_STR[expr_value(selecting_sym.direct_dep)]})"
             )
 
             if select.__class__ is tuple:
-                msg += ", and select condition {} (value: {})".format(
-                    expr_str(select[2]), TRI_TO_STR[expr_value(select[2])]
-                )
+                msg += f", and select condition {expr_str(select[2])} (value: {TRI_TO_STR[expr_value(select[2])]})"
 
         self.kconfig._warn(msg)
 
 
-class Choice(object):
+class Choice:
     """
     Represents a choice statement:
 
@@ -5616,7 +5508,7 @@ class Choice(object):
             self.kconfig._warn(
                 "the value {} is invalid for {}, which has type {} -- "
                 "assignment ignored".format(
-                    TRI_TO_STR[value] if value in TRI_TO_STR else "'{}'".format(value),
+                    TRI_TO_STR[value] if value in TRI_TO_STR else f"'{value}'",
                     self.name_and_loc,
                     TYPE_TO_STR[self.orig_type],
                 )
@@ -5668,18 +5560,18 @@ class Choice(object):
 
         for node in self.nodes:
             if node.prompt:
-                add('"{}"'.format(node.prompt[0]))
+                add(f'"{node.prompt[0]}"')
 
         add("mode " + self.str_value)
 
         if self.user_value is not None:
-            add("user mode {}".format(TRI_TO_STR[self.user_value]))
+            add(f"user mode {TRI_TO_STR[self.user_value]}")
 
         if self.selection:
-            add("{} selected".format(self.selection.name))
+            add(f"{self.selection.name} selected")
 
         if self.user_selection:
-            user_sel_str = "{} selected by user".format(self.user_selection.name)
+            user_sel_str = f"{self.user_selection.name} selected by user"
 
             if self.selection is not self.user_selection:
                 user_sel_str += " (overridden)"
@@ -5778,7 +5670,7 @@ class Choice(object):
         # function call (property magic).  Accessing self.visibility ensures
         # _cached_vis is set, which the invalidation system uses as the flag
         # for "has cached values that need clearing".
-        self.visibility
+        self.visibility  # noqa: B018
 
         # sym_calc_choice() in scripts/kconfig/symbol.c (Linux) computes
         # the selection for any choice that has visible members, regardless
@@ -5848,7 +5740,7 @@ class Choice(object):
                 item._rec_invalidate()
 
 
-class MenuNode(object):
+class MenuNode:
     """
     Represents a menu node in the configuration. This corresponds to an entry
     in e.g. the 'make menuconfig' interface, though non-visible choices, menus,
@@ -6141,9 +6033,7 @@ class MenuNode(object):
 
         if self.prompt:
             add(
-                'prompt "{}" (visibility {})'.format(
-                    self.prompt[0], TRI_TO_STR[expr_value(self.prompt[1])]
-                )
+                f'prompt "{self.prompt[0]}" (visibility {TRI_TO_STR[expr_value(self.prompt[1])]})'
             )
 
         if self.item.__class__ is Symbol and self.is_menuconfig:
@@ -6201,10 +6091,10 @@ class MenuNode(object):
         s = '{} "{}"'.format("menu" if self.item is MENU else "comment", self.prompt[0])
 
         if self.dep is not self.kconfig.y:
-            s += "\n\tdepends on {}".format(expr_str(self.dep, sc_expr_str_fn))
+            s += f"\n\tdepends on {expr_str(self.dep, sc_expr_str_fn)}"
 
         if self.item is MENU and self.visibility is not self.kconfig.y:
-            s += "\n\tvisible if {}".format(expr_str(self.visibility, sc_expr_str_fn))
+            s += f"\n\tvisible if {expr_str(self.visibility, sc_expr_str_fn)}"
 
         return s
 
@@ -6237,7 +6127,7 @@ class MenuNode(object):
                 prefix = "prompt"
 
             indent_add_cond(
-                prefix + ' "{}"'.format(escape(self.prompt[0])), self.orig_prompt[1]
+                prefix + f' "{escape(self.prompt[0])}"', self.orig_prompt[1]
             )
 
         if sc.__class__ is Symbol:
@@ -6248,14 +6138,14 @@ class MenuNode(object):
                 indent_add("option defconfig_list")
 
             if sc.env_var is not None:
-                indent_add('option env="{}"'.format(sc.env_var))
+                indent_add(f'option env="{sc.env_var}"')
 
             if sc is sc.kconfig.modules:
                 indent_add("option modules")
 
             for low, high, cond in self.orig_ranges:
                 indent_add_cond(
-                    "range {} {}".format(sc_expr_str_fn(low), sc_expr_str_fn(high)),
+                    f"range {sc_expr_str_fn(low)} {sc_expr_str_fn(high)}",
                     cond,
                 )
 
@@ -6298,7 +6188,7 @@ class MenuNode(object):
         return expr
 
 
-class Variable(object):
+class Variable:
     """
     Represents a preprocessor variable/function.
 
@@ -6360,16 +6250,14 @@ class KconfigError(Exception):
 
 # Workaround:
 #
-# If 'errno' and 'strerror' are set on IOError, then __str__() always returns
+# If 'errno' and 'strerror' are set on OSError, then __str__() always returns
 # "[Errno <errno>] <strerror>", ignoring any custom message passed to the
 # constructor. By defining our own subclass, we can use a custom message while
 # also providing 'errno', 'strerror', and 'filename' to scripts.
-class _KconfigIOError(IOError):
+class _KconfigIOError(OSError):
     def __init__(self, ioerror, msg):
         self.msg = msg
-        super(_KconfigIOError, self).__init__(
-            ioerror.errno, ioerror.strerror, ioerror.filename
-        )
+        super().__init__(ioerror.errno, ioerror.strerror, ioerror.filename)
 
     def __str__(self):
         return self.msg
@@ -6452,10 +6340,10 @@ def standard_sc_expr_str(sc):
     """
     if sc.__class__ is Symbol:
         if sc.is_constant and sc.name not in STR_TO_TRI:
-            return '"{}"'.format(escape(sc.name))
+            return f'"{escape(sc.name)}"'
         return sc.name
 
-    return "<choice {}>".format(sc.name) if sc.name else "<choice>"
+    return f"<choice {sc.name}>" if sc.name else "<choice>"
 
 
 def expr_str(expr, sc_expr_str_fn=standard_sc_expr_str):
@@ -6480,31 +6368,23 @@ def expr_str(expr, sc_expr_str_fn=standard_sc_expr_str):
         return sc_expr_str_fn(expr)
 
     if expr[0] is AND:
-        return "{} && {}".format(
-            _parenthesize(expr[1], OR, sc_expr_str_fn),
-            _parenthesize(expr[2], OR, sc_expr_str_fn),
-        )
+        return f"{_parenthesize(expr[1], OR, sc_expr_str_fn)} && {_parenthesize(expr[2], OR, sc_expr_str_fn)}"
 
     if expr[0] is OR:
         # This turns A && B || C && D into "(A && B) || (C && D)", which is
         # redundant, but more readable
-        return "{} || {}".format(
-            _parenthesize(expr[1], AND, sc_expr_str_fn),
-            _parenthesize(expr[2], AND, sc_expr_str_fn),
-        )
+        return f"{_parenthesize(expr[1], AND, sc_expr_str_fn)} || {_parenthesize(expr[2], AND, sc_expr_str_fn)}"
 
     if expr[0] is NOT:
         if expr[1].__class__ is tuple:
-            return "!({})".format(expr_str(expr[1], sc_expr_str_fn))
+            return f"!({expr_str(expr[1], sc_expr_str_fn)})"
         return "!" + sc_expr_str_fn(expr[1])  # Symbol
 
     # Relation
     #
     # Relation operands are always symbols (quoted strings are constant
     # symbols)
-    return "{} {} {}".format(
-        sc_expr_str_fn(expr[1]), REL_TO_STR[expr[0]], sc_expr_str_fn(expr[2])
-    )
+    return f"{sc_expr_str_fn(expr[1])} {REL_TO_STR[expr[0]]} {sc_expr_str_fn(expr[2])}"
 
 
 def expr_items(expr):
@@ -6751,7 +6631,7 @@ def _parenthesize(expr, type_, sc_expr_str_fn):
     # expr_str() helper. Adds parentheses around expressions of type 'type_'.
 
     if expr.__class__ is tuple and expr[0] is type_:
-        return "({})".format(expr_str(expr, sc_expr_str_fn))
+        return f"({expr_str(expr, sc_expr_str_fn)})"
     return expr_str(expr, sc_expr_str_fn)
 
 
@@ -6828,7 +6708,7 @@ def _save_old(path):
 
     try:
         copy_fn(path, path + ".old")
-    except (OSError, IOError, shutil.Error):
+    except (OSError, shutil.Error):
         # Ignore errors from 'path' missing as well as other errors.
         # <filename>.old file is usually more of a nice-to-have, and not worth
         # erroring out over e.g. if <filename>.old happens to be a directory or
@@ -7098,7 +6978,7 @@ def _found_dep_loop(loop, cur):
             if item.__class__ is Symbol and item.choice:
                 msg += "the choice symbol "
 
-        msg += "{}, with definition...\n\n{}\n\n".format(item.name_and_loc, item)
+        msg += f"{item.name_and_loc}, with definition...\n\n{item}\n\n"
 
         # Small wart: Since we reuse the already calculated
         # Symbol/Choice._dependents sets for recursive dependency detection, we
@@ -7115,13 +6995,11 @@ def _found_dep_loop(loop, cur):
 
         if item.__class__ is Symbol:
             if item.rev_dep is not item.kconfig.n:
-                msg += "(select-related dependencies: {})\n\n".format(
-                    expr_str(item.rev_dep)
-                )
+                msg += f"(select-related dependencies: {expr_str(item.rev_dep)})\n\n"
 
             if item.weak_rev_dep is not item.kconfig.n:
-                msg += "(imply-related dependencies: {})\n\n".format(
-                    expr_str(item.weak_rev_dep)
+                msg += (
+                    f"(imply-related dependencies: {expr_str(item.weak_rev_dep)})\n\n"
                 )
 
     msg += "...depends again on " + loop[0].name_and_loc
@@ -7145,9 +7023,9 @@ def _decoding_error(e, filename, macro_linenr=None):
         "Reason: {}".format(
             e.encoding,
             (
-                "'{}'".format(filename)
+                f"'{filename}'"
                 if macro_linenr is None
-                else "output from macro at {}:{}".format(filename, macro_linenr)
+                else f"output from macro at {filename}:{macro_linenr}"
             ),
             e.object[max(e.start - 40, 0) : e.end + 40],
             e.object[e.start : e.end],
@@ -7158,12 +7036,12 @@ def _decoding_error(e, filename, macro_linenr=None):
 
 def _warn_verbose_deprecated(fn_name):
     sys.stderr.write(
-        "Deprecation warning: {0}()'s 'verbose' argument has no effect. Since "
-        "Kconfiglib 12.0.0, the message is returned from {0}() instead, "
-        "and is always generated. Do e.g. print(kconf.{0}()) if you want to "
+        f"Deprecation warning: {fn_name}()'s 'verbose' argument has no effect. Since "
+        f"Kconfiglib 12.0.0, the message is returned from {fn_name}() instead, "
+        f"and is always generated. Do e.g. print(kconf.{fn_name}()) if you want to "
         "want to show a message like \"Loaded configuration '.config'\" on "
         "stdout. The old API required ugly hacks to reuse messages in "
-        "configuration interfaces.\n".format(fn_name)
+        "configuration interfaces.\n"
     )
 
 
@@ -7179,7 +7057,7 @@ def _lineno_fn(kconf, _):
 
 
 def _info_fn(kconf, _, msg):
-    print("{}:{}: {}".format(kconf.filename, kconf.linenr, msg))
+    print(f"{kconf.filename}:{kconf.linenr}: {msg}")
 
     return ""
 
@@ -7193,7 +7071,7 @@ def _warning_if_fn(kconf, _, cond, msg):
 
 def _error_if_fn(kconf, _, cond, msg):
     if cond == "y":
-        raise KconfigError("{}:{}: {}".format(kconf.filename, kconf.linenr, msg))
+        raise KconfigError(f"{kconf.filename}:{kconf.linenr}: {msg}")
 
     return ""
 
@@ -7283,7 +7161,7 @@ def _cc_option_fn(kconf, _, option, fallback=""):
 
 def _ld_option_fn(kconf, _, option):
     ld = os.environ.get("LD", "ld")
-    return "y" if _run_cmd("{} -v {} 2>/dev/null".format(ld, option)) else "n"
+    return "y" if _run_cmd(f"{ld} -v {option} 2>/dev/null") else "n"
 
 
 def _as_instr_fn(kconf, _, instr, extra_flags=""):
@@ -7322,11 +7200,7 @@ def _cc_option_bit_fn(kconf, _, option):
     cc = os.environ.get("CC", "gcc")
     return (
         option
-        if _run_cmd(
-            "{} -Werror {} -E -x c /dev/null -o /dev/null 2>/dev/null".format(
-                cc, option
-            )
-        )
+        if _run_cmd(f"{cc} -Werror {option} -E -x c /dev/null -o /dev/null 2>/dev/null")
         else ""
     )
 
@@ -7344,9 +7218,7 @@ def _rustc_option_fn(kconf, _, option):
         with open(dummy_rs, "w") as f:
             f.write("")
 
-        cmd = (
-            "{} {} --crate-type=rlib {} --out-dir={} -o {}/tmp.rlib 2>/dev/null"
-        ).format(rustc, option, dummy_rs, tmpdir, tmpdir)
+        cmd = f"{rustc} {option} --crate-type=rlib {dummy_rs} --out-dir={tmpdir} -o {tmpdir}/tmp.rlib 2>/dev/null"
 
         return "y" if _run_cmd(cmd) else "n"
     except Exception:

--- a/listnewconfig.py
+++ b/listnewconfig.py
@@ -55,9 +55,7 @@ def main():
             # to show n-valued symbols as 'CONFIG_FOO=n' instead of
             # '# CONFIG_FOO is not set'. This matches the C tools.
             if sym.orig_type in (BOOL, TRISTATE):
-                s = "{}{}={}\n".format(
-                    kconf.config_prefix, sym.name, TRI_TO_STR[sym.tri_value]
-                )
+                s = f"{kconf.config_prefix}{sym.name}={TRI_TO_STR[sym.tri_value]}\n"
             else:
                 s = sym.config_string
 

--- a/oldconfig.py
+++ b/oldconfig.py
@@ -93,9 +93,7 @@ def oldconfig(node):
         # (for the default value)
         while True:
             val = input(
-                "{} ({}) [{}] ".format(
-                    node.prompt[0], _name_and_loc_str(sym), _default_value_str(sym)
-                )
+                f"{node.prompt[0]} ({_name_and_loc_str(sym)}) [{_default_value_str(sym)}] "
             )
 
             if val == "?":
@@ -158,7 +156,7 @@ def oldconfig(node):
         # Loop until the user enters a valid selection or a blank string (for
         # the default selection)
         while True:
-            print("{} ({})".format(node.prompt[0], _name_and_loc_str(choice)))
+            print(f"{node.prompt[0]} ({_name_and_loc_str(choice)})")
 
             for i, sym in enumerate(options, 1):
                 print(
@@ -172,7 +170,7 @@ def oldconfig(node):
                     )
                 )
 
-            sel_index = input("choice[1-{}]: ".format(len(options)))
+            sel_index = input(f"choice[1-{len(options)}]: ")
 
             if sel_index == "?":
                 _print_help(node)
@@ -221,7 +219,7 @@ def _name_and_loc_str(sc):
 
     return "{}, defined at {}".format(
         sc.name or "choice",
-        ", ".join("{}:{}".format(node.filename, node.linenr) for node in sc.nodes),
+        ", ".join(f"{node.filename}:{node.linenr}" for node in sc.nodes),
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,49 @@
+[tool.ruff]
+# Project supports >=3.6, but Ruff's minimum target is py37.
+# No py37-only syntax is introduced by the enabled rules.
+target-version = "py37"
+# Lint installable modules and dev tools; skip non-shipping directories
+extend-exclude = ["examples", "tests", ".ci", "externals"]
+
+[tool.ruff.lint]
+# Enable rule categories for genuine code quality checks
+select = [
+    "F",      # Pyflakes: unused imports/variables, undefined names
+    "E",      # pycodestyle errors
+    "W",      # pycodestyle warnings
+    "UP",     # pyupgrade: Python version upgrades (object inheritance, super(), f-strings)
+    "B",      # flake8-bugbear: common bugs (mutable defaults, raise-without-from)
+    "A",      # flake8-builtins: shadowing builtins
+    "PLE",    # pylint errors (0 current hits, free safety net)
+    "PLW",    # pylint warnings (unnecessary-lambda, global-variable-not-assigned)
+    "PLR1714",# pylint refactor: repeated-equality-comparison (consider-using-in)
+    "PLR1730",# pylint refactor: if-stmt-min-max (consider-using-max-builtin)
+    "PLR0402",# pylint refactor: manual-from-import (consider-using-from-import)
+    "BLE",    # flake8-blind-except: catch blind Exception
+    "S102",   # flake8-bandit: exec builtin
+    "S110",   # flake8-bandit: try-except-pass
+    "S301",   # flake8-bandit: pickle usage
+    "S307",   # flake8-bandit: eval usage
+    "S602",   # flake8-bandit: subprocess shell=True
+    "SIM115", # flake8-simplify: context manager for open()
+]
+ignore = [
+    # Line length handled by black formatter (enforced in CI)
+    "E501",   # line-too-long
+]
+
+[tool.ruff.lint.per-file-ignores]
+# kconfiglib: type/format as API params, parser loop reassignment is intentional,
+# shell=True required for $(shell) expansion, defensive except-Exception in
+# subprocess/tmpdir cleanup
+"kconfiglib.py" = ["A001", "PLW2901", "S602", "BLE001", "S110"]
+# menuconfig: module-level globals, conditional imports, global-statement,
+# defensive except-Exception in terminal shadow/suspend ops
+"menuconfig.py" = ["PLW0602", "E402", "PLW0603", "BLE001", "S110"]
+# guiconfig: tkinter wildcard imports, module-level globals, global-statement,
+# outer loop variable reuse in menu population
+"guiconfig.py" = ["F403", "F405", "PLW0602", "PLW0603", "PLW2901"]
+# lint: global-statement, defensive except-Exception for git grep fallback
+"lint.py" = ["PLW0603", "BLE001", "S110"]
+# oldconfig: global-statement for conf_changed flag
+"oldconfig.py" = ["PLW0603"]

--- a/rawterm.py
+++ b/rawterm.py
@@ -35,7 +35,6 @@ _IS_WINDOWS = os.name == "nt"
 if not _IS_WINDOWS:
     import select
     import termios
-    import tty
 
 
 # ---------------------------------------------------------------------------
@@ -95,9 +94,9 @@ class Color:
                 return str(30 + idx)
             return str(90 + idx - 8)
         if self._kind == "index":
-            return "38;5;{}".format(self._value)
+            return f"38;5;{self._value}"
         r, g, b = self._value
-        return "38;2;{};{};{}".format(r, g, b)
+        return f"38;2;{r};{g};{b}"
 
     def _sgr_bg(self):
         """Return SGR escape for background."""
@@ -109,9 +108,9 @@ class Color:
                 return str(40 + idx)
             return str(100 + idx - 8)
         if self._kind == "index":
-            return "48;5;{}".format(self._value)
+            return f"48;5;{self._value}"
         r, g, b = self._value
-        return "48;2;{};{};{}".format(r, g, b)
+        return f"48;2;{r};{g};{b}"
 
     def __eq__(self, other):
         if not isinstance(other, Color):
@@ -128,11 +127,9 @@ class Color:
         if self._kind == "default":
             return "Color.DEFAULT"
         if self._kind == "named":
-            return Color._NAMED_REPRS.get(
-                self._value, "Color('named', {})".format(self._value)
-            )
+            return Color._NAMED_REPRS.get(self._value, f"Color('named', {self._value})")
         if self._kind == "index":
-            return "Color.index({})".format(self._value)
+            return f"Color.index({self._value})"
         return "Color.rgb({},{},{})".format(*self._value)
 
 
@@ -251,9 +248,9 @@ class Style:
     def __repr__(self):
         parts = []
         if self.fg != Color.DEFAULT:
-            parts.append("fg={}".format(self.fg))
+            parts.append(f"fg={self.fg}")
         if self.bg != Color.DEFAULT:
-            parts.append("bg={}".format(self.bg))
+            parts.append(f"bg={self.bg}")
         if self.bold:
             parts.append("bold")
         if self.standout:
@@ -860,7 +857,7 @@ class Terminal:
 
                 # Move cursor if not contiguous
                 if row != last_row or col != last_col:
-                    buf.append("\x1b[{};{}H".format(row + 1, col + 1))
+                    buf.append(f"\x1b[{row + 1};{col + 1}H")
 
                 # Set style if changed
                 if style != last_style:
@@ -881,7 +878,7 @@ class Terminal:
             r = self._cursor_region
             abs_y = r._y + self._cursor_y
             abs_x = r._x + self._cursor_x
-            buf.append("\x1b[{};{}H".format(abs_y + 1, abs_x + 1))
+            buf.append(f"\x1b[{abs_y + 1};{abs_x + 1}H")
             if self._cursor_very_visible:
                 buf.append("\x1b[?12;25h")  # blink + show
             else:

--- a/setconfig.py
+++ b/setconfig.py
@@ -63,28 +63,26 @@ def main():
 
     for arg in args.assignments:
         if "=" not in arg:
-            sys.exit("error: no '=' in assignment: '{}'".format(arg))
+            sys.exit(f"error: no '=' in assignment: '{arg}'")
         name, value = arg.split("=", 1)
 
         if name not in kconf.syms:
             if not args.check_exists:
                 continue
-            sys.exit("error: no symbol '{}' in configuration".format(name))
+            sys.exit(f"error: no symbol '{name}' in configuration")
 
         sym = kconf.syms[name]
 
         if not sym.set_value(value):
             sys.exit(
-                "error: '{}' is an invalid value for the {} symbol {}".format(
-                    value, kconfiglib.TYPE_TO_STR[sym.orig_type], name
-                )
+                f"error: '{value}' is an invalid value for the {kconfiglib.TYPE_TO_STR[sym.orig_type]} symbol {name}"
             )
 
         if args.check_value and sym.str_value != value:
             sys.exit(
-                "error: {} was assigned the value '{}', but got the "
-                "value '{}'. Check the symbol's dependencies, and make "
-                "sure that it has a prompt.".format(name, value, sym.str_value)
+                f"error: {name} was assigned the value '{value}', but got the "
+                f"value '{sym.str_value}'. Check the symbol's dependencies, and make "
+                "sure that it has a prompt."
             )
 
     print(kconf.write_config())


### PR DESCRIPTION
This integrates [Ruff](https://github.com/astral-sh/ruff) as static analysis linter alongside the existing black formatter. The pyproject.toml configures targeted rule categories (Pyflakes, pycodestyle, pyupgrade, flake8-bugbear, flake8-builtins, and select pylint rules) with per-file ignores for structural patterns like tkinter wildcard imports and module-level globals in TUI/GUI code.

Code fixes applied across all three source files:
- Convert 189 .format() calls to f-strings
- Replace EnvironmentError/IOError aliases with OSError (16 sites)
- Remove useless (object) inheritance from 5 classes
- Add 'from e' to 2 re-raised exceptions for proper chaining
- Eliminate mutable default arguments in cache functions by using module-level lists with .clear() on re-entry
- Simplify comparisons with 'in', max(), and direct function refs
- Modernize super() call and from-import style
- Remove dead variable assignment and update stale docstrings

Close #11

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Ruff linter with CI enforcement and project config. Cleaned up code to satisfy lint rules, fixed cached-node state leakage in TUI/GUI search, and corrected the option-env warning message arguments.

- **Refactors**
  - Converted .format() calls to f-strings.
  - Standardized exceptions (use OSError, add chaining, avoid bare except).
  - Modernized imports and super(); removed redundant “object” bases.
  - Simplified comparisons and control flow.

- **Bug Fixes**
  - Cleared cached node lists on TUI/GUI re-entry to prevent stale search results.
  - Fixed option-env warning to use the correct argument order.

<sup>Written for commit 460ab775b68f7914bbffed311fb4a66570d1f9f2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

