### PR TITLE
Add `$(python,...)` built-in

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,12 +88,17 @@ jobs:
         path: ${{ matrix.target.headless-only && '.' || 'Kconfiglib' }}
 
     - name: Run pytest selftests
-      # Skip on Windows: several tests depend on Unix shell ($(shell,...)),
-      # gcc, and forward-slash paths that are unavailable on Windows CI.
-      if: ${{ matrix.target.headless-only != true }}
       working-directory: ${{ matrix.target.headless-only && '.' || 'Kconfiglib' }}
       run: |
-        python -m pytest tests/ -v --tb=short --ignore=tests/test_conformance.py
+        if [ "${{ matrix.target.headless-only }}" == "true" ]; then
+          # Windows: portable subset -- excludes tests that need gcc or
+          # Unix shell commands (Kpreprocess uses $(shell,...) with
+          # bash-specific syntax).
+          python -m pytest tests/test_preprocess.py -v --tb=short \
+            -k "test_user_defined or test_success_failure or test_python_fn or test_kconfig_warn"
+        else
+          python -m pytest tests/ -v --tb=short --ignore=tests/test_conformance.py
+        fi
 
     - name: Apply Linux Kconfig Makefile patch
       # Skip for Windows (headless-only mode)

--- a/tests/Kbuild_functions
+++ b/tests/Kbuild_functions
@@ -1,19 +1,81 @@
-# Test Kbuild toolchain test functions
+# Test Kbuild toolchain test functions and $(python,...) built-in
 
-config TEST_SUCCESS
-	def_bool $(success,true)
-	help
-	  Test success function with command that returns 0
+# --- $(python,...) tests ---
 
-config TEST_FAILURE
-	def_bool $(failure,false)
+config TEST_PYTHON_SUCCESS
+	def_bool $(python,)
 	help
-	  Test failure function with command that returns 0
+	  Empty code string = success = "y"
 
-config TEST_IF_SUCCESS
-	def_bool $(if-success,true,y,n)
+config TEST_PYTHON_ASSERT_PASS
+	def_bool $(python,assert not "")
 	help
-	  Test if-success function with true command
+	  Assertion that passes = "y"
+
+config TEST_PYTHON_ASSERT_FAIL
+	def_bool $(python,assert False)
+	help
+	  Assertion that fails = "n"
+
+config TEST_PYTHON_ENV
+	def_bool $(python,assert os.environ.get('CC'))
+	help
+	  Check env var via os module
+
+config TEST_PYTHON_WHICH
+	def_bool $(python,assert shutil.which('python3') or shutil.which('python'))
+	help
+	  Tool detection via shutil.which
+
+config TEST_PYTHON_RUN
+	def_bool $(python,assert run(sys.executable, '-c', ''))
+	help
+	  Shell-free subprocess via run()
+
+config TEST_PYTHON_RUN_FAIL
+	def_bool $(python,assert not run(sys.executable, '-c', 'raise SystemExit(1)'))
+	help
+	  Verify run() failure detection
+
+config TEST_PYTHON_QUOTE_COMMA
+	def_bool $(python,assert "a,b" == "a,b")
+	help
+	  Commas inside double quotes must not split arguments
+
+config TEST_PYTHON_QUOTE_PAREN
+	def_bool $(python,assert "(" + ")" == "()")
+	help
+	  Parentheses inside quotes must not affect nesting
+
+config TEST_PYTHON_SINGLE_QUOTE
+	def_bool $(python,assert 'x,y' == 'x,y')
+	help
+	  Single-quoted commas must not split arguments
+
+config TEST_PYTHON_ESCAPED_QUOTE
+	def_bool $(python,assert "a\"b" == 'a"b')
+	help
+	  Backslash-escaped quotes must not end quoted region
+
+config TEST_PYTHON_TRIPLE_QUOTE
+	def_bool $(python,assert """a,b"c""" == 'a,b"c')
+	help
+	  Triple-quoted string with comma and embedded quote
+
+config TEST_PYTHON_TRIPLE_SINGLE
+	def_bool $(python,assert '''x,y'z''' == "x,y'z")
+	help
+	  Triple single-quoted string with comma and embedded quote
+
+GREETING = hello
+
+config TEST_PYTHON_MACRO_BEFORE_ESCAPE
+	def_bool $(python,assert "$(GREETING)\n" == "hello\n")
+	help
+	  Macro expansion must happen before backslash-escape processing
+	  inside quoted regions so $(GREETING) is expanded, not skipped.
+
+# --- Toolchain function tests (cc-option, ld-option, etc.) ---
 
 config CC_HAS_WALL
 	def_bool $(cc-option,-Wall)
@@ -56,30 +118,9 @@ config CC_STACK_USAGE_FLAG
 	help
 	  Returns -fstack-usage if supported, empty otherwise
 
-# Test nested function calls
-config TEST_NESTED_SUCCESS_SHELL
-	def_bool $(success,test -n "$(shell,echo test)")
-	help
-	  Test nested success and shell function calls
+# --- Failure cases ---
 
-config TEST_NESTED_IF_SUCCESS
-	def_bool $(if-success,test -z "$(shell,echo)",y,n)
-	help
-	  Test deeply nested function calls with if-success
-
-# Test with environment variables
-config TEST_CC_ENV
-	def_bool $(success,test -n "$CC")
-	help
-	  Test if CC environment variable is set
-
-# Test failure cases
 config TEST_INVALID_OPTION
 	def_bool $(cc-option,--this-option-does-not-exist-xyz)
 	help
 	  Test cc-option with invalid flag (should return n)
-
-config TEST_FAILURE_TRUE
-	def_bool $(failure,true)
-	help
-	  Test failure with true command (should return n)


### PR DESCRIPTION
This introduces a portable $(python,...) preprocessor function that evaluates a Python code string in-process via exec(), returning "y" on success and "n" on exception. 'exec' namespace exposes os, sys, shutil, platform, and a shell-free run(*argv) helper for subprocess checks. Each call receives a fresh globals copy for namespace isolation.

Rewrite all six toolchain functions (cc-option, ld-option, as-instr, as-option, cc-option-bit, rustc-option) to use subprocess.Popen with argument lists (shell=False) and os.devnull, eliminating /dev/null, 2>/dev/null, and printf-pipe constructs.  This closes the shell injection vector from environment variables and makes the functions work on Windows.

Add _run_argv() helper with timeout support and proper process cleanup. Remove dead _run_cmd_in_tmpdir(); replaced by TemporaryDirectory context managers in individual functions.

Add quote tracking to the macro expander so that commas and parentheses inside single, double, and triple-quoted strings are not treated as argument separators (required for $(python,assert "a,b" == "a,b")).

Close #41

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a portable $(python,...) built-in for in-process boolean checks and makes all Kbuild toolchain functions shell-free and Windows-compatible. Improves macro expansion with robust quote handling and adds subprocess timeouts. Closes #41.

- **New Features**
  - Added $(python,code): execs in-process, returns y on success and n on exception; exposes os, sys, shutil, platform, and run(*argv) in a fresh namespace per call.
  - SystemExit(0/None/"") → y; non-zero/truthy → n. AssertionError is silent; other exceptions emit a warning with type and message.
  - Macro expander now tracks single/double/triple quotes and escapes; nested macros inside quotes still expand, and commas/parentheses inside quotes are not treated as separators.
  - Updated KBUILD.md with usage examples, portability guidance, and quoting behavior.

- **Refactors**
  - Rewrote cc-option, ld-option, as-instr, as-option, cc-option-bit, and rustc-option to use subprocess.Popen with argv (shell=False) and os.devnull; removes shell injection risk and works on Windows.
  - Added _run_argv() with a 30s timeout and proper cleanup; _run_cmd now uses DEVNULL and a timeout. Exposed shell-free run() to $(python,...) code.
  - Removed _run_cmd_in_tmpdir(); callers use TemporaryDirectory. Expanded tests to cover $(python,...) and quote tracking.

<sup>Written for commit 4c399d964603d0144011512314f201fae62f04ea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

