### PR TITLE
Refine CI workflows

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -13,10 +13,18 @@ concurrency:
   group: package-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  PYTHONUNBUFFERED: "1"
+
 jobs:
   package:
     name: Package
     runs-on: ubuntu-24.04
+
+    defaults:
+      run:
+        shell: bash
 
     steps:
     - name: Set up Python
@@ -24,15 +32,10 @@ jobs:
       with:
         python-version: '3.12'
 
-    - name: Check Python version
-      run: |
-        set -x
-        python --version
-        pip --version
-        python -c "import platform; print(platform.architecture())"
-
     - name: Install Python dependencies
       run: |
+        set -euo pipefail
+        python -m pip install --user --upgrade pip
         pip install --user setuptools wheel
 
     - name: Check out Kconfiglib source code
@@ -40,14 +43,34 @@ jobs:
 
     - name: Build source distribution
       run: |
+        set -euo pipefail
         python setup.py sdist
 
     - name: Build built distribution wheel
       run: |
+        set -euo pipefail
         python setup.py bdist_wheel
+
+    - name: List built artifacts
+      run: |
+        set -euo pipefail
+        ls -la dist/
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v6
       with:
         name: dist
         path: dist/*
+
+    - name: Diagnostic dump on failure
+      if: failure()
+      run: |
+        set +e
+        echo "::group::dist/ and build/ contents"
+        ls -la dist/ 2>/dev/null
+        ls -laR build/ 2>/dev/null | head -200
+        echo "::endgroup::"
+        echo "::group::Python environment"
+        python --version
+        python -m pip list
+        echo "::endgroup::"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,10 @@ jobs:
     needs: [ test, package ]
     runs-on: ubuntu-24.04
 
+    defaults:
+      run:
+        shell: bash
+
     permissions:
       contents: write
       id-token: write
@@ -27,11 +31,37 @@ jobs:
     - name: Download build artifacts
       uses: actions/download-artifact@v7
 
+    - name: List downloaded artifacts
+      run: |
+        set -euo pipefail
+        ls -la dist/
+
     - name: Upload release assets
       uses: softprops/action-gh-release@v2
       with:
         files: |
           dist/*.whl
+          dist/*.tar.gz
 
     - name: Publish package to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
+
+    - name: Diagnostic dump on failure
+      if: failure()
+      # Release tag/name are user-controlled input, so never interpolate them
+      # directly into the shell body. Pass through env: and expand with
+      # shell-safe quoting inside the script.
+      env:
+        RELEASE_TAG: ${{ github.event.release.tag_name }}
+        RELEASE_DRAFT: ${{ github.event.release.draft }}
+        RELEASE_PRERELEASE: ${{ github.event.release.prerelease }}
+      run: |
+        set +e
+        echo "::group::dist/ contents"
+        ls -la dist/ 2>/dev/null
+        echo "::endgroup::"
+        echo "::group::Release context"
+        printf 'tag:        %s\n' "$RELEASE_TAG"
+        printf 'draft:      %s\n' "$RELEASE_DRAFT"
+        printf 'prerelease: %s\n' "$RELEASE_PRERELEASE"
+        echo "::endgroup::"

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -6,10 +6,18 @@ concurrency:
   group: style-check-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  PYTHONUNBUFFERED: "1"
+
 jobs:
   format-check:
     name: Check Code Format
     runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash
 
     steps:
     - name: Check out Kconfiglib source code
@@ -22,14 +30,30 @@ jobs:
 
     - name: Install tools
       run: |
-           sudo apt-get install -q=2 shfmt python3-pip
-           pip3 install black==26.1.0 ruff==0.15.2
+        set -euo pipefail
+        sudo apt-get install -q=2 shfmt python3-pip
+        pip3 install black==26.1.0 ruff==0.15.2
 
     - name: Run format check
       run: |
-           .ci/check-newline.sh
-           .ci/check-format.sh
-      shell: bash
+        set -euo pipefail
+        .ci/check-newline.sh
+        .ci/check-format.sh
 
     - name: Run Ruff linter
-      run: ruff check .
+      run: |
+        set -euo pipefail
+        ruff check --output-format=full .
+
+    - name: Diagnostic dump on failure
+      if: failure()
+      run: |
+        set +e
+        echo "::group::Tool versions"
+        shfmt --version
+        black --version
+        ruff --version
+        echo "::endgroup::"
+        echo "::group::Black diff"
+        black --diff --color .
+        echo "::endgroup::"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,14 +1,29 @@
 name: Test
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  workflow_call:
 
 concurrency:
   group: test-${{ github.ref }}
   cancel-in-progress: true
 
+# Verbose pytest defaults: long tracebacks, locals, and a short test summary
+# (-ra) so failed/skipped/xfailed tests are listed at the end of the log
+# instead of buried in the middle. Applied via env so every pytest invocation
+# in this workflow inherits the same diagnostics.
+env:
+  PYTEST_ADDOPTS: "-vv --tb=long --showlocals -ra --color=yes"
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  PYTHONUNBUFFERED: "1"
+
 jobs:
-  test:
-    name: Test (Python ${{ matrix.target.python }}, ${{ matrix.target.os }})
+  # Fast pytest selftests + rawterm/menuconfig smoke test on all platforms.
+  # Independent of the kernel tree, so it returns feedback quickly and runs
+  # in parallel with the slower conformance job below.
+  selftest:
+    name: Selftest (Python ${{ matrix.target.python }}, ${{ matrix.target.os }})
     runs-on: ${{ matrix.target.builder }}
 
     defaults:
@@ -18,9 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # NOTE: Windows runs only headless tests (no kernel tree, no Unix
-        #       shell). Linux/macOS run selftests, conformance tests, and
-        #       example scripts.
+        # NOTE: Windows runs only the headless-portable subset (no Unix shell).
         target:
         - python: '3.12'
           os: Linux
@@ -34,28 +47,97 @@ jobs:
           headless-only: true
 
     steps:
-    - name: Set up environment
-      run: |
-        if [ "${{ runner.os }}" == "Windows" ]; then
-          # Disable file name validation on Windows because Linux source tree
-          # contains potentially problematic file names.
-          git config --global core.protectNTFS false
-        fi
-
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.target.python }}
 
-    - name: Check Python version
+    - name: Install Python dependencies
       run: |
-        set -x
+        set -euo pipefail
+        python -m pip install --user --upgrade pip
+        python -m pip install --user setuptools wheel pytest
+
+    - name: Check out Kconfiglib source code
+      uses: actions/checkout@v6
+
+    - name: Run pytest selftests
+      run: |
+        set -euo pipefail
+        if [ "${{ matrix.target.headless-only }}" == "true" ]; then
+          # Windows: portable subset -- excludes tests that need gcc or
+          # Unix shell commands (Kpreprocess uses $(shell,...) with
+          # bash-specific syntax).
+          python -m pytest tests/test_preprocess.py \
+            -k "test_user_defined or test_success_failure or test_python_fn or test_kconfig_warn"
+        else
+          python -m pytest tests/ --ignore=tests/test_conformance.py
+        fi
+
+    - name: Validate rawterm and menuconfig (Unix)
+      # Exercises rawterm Color/Style/Region compositing, terminal init/close
+      # (termios on Unix), and menuconfig headless mode with style parsing.
+      if: ${{ matrix.target.os != 'Windows' }}
+      run: |
+        set -euo pipefail
+        python .ci/validate-rawterm.py
+
+    - name: Validate rawterm and menuconfig (Windows)
+      # On Windows, use cmd so Python gets real console handles (bash
+      # runs through MSYS2/mintty which lacks a native Windows console).
+      if: ${{ matrix.target.os == 'Windows' }}
+      shell: cmd
+      run: |
+        python .ci/validate-rawterm.py
+        if errorlevel 1 exit /b %errorlevel%
+
+    - name: Diagnostic dump on failure
+      if: failure()
+      shell: bash
+      run: |
+        # Best-effort diagnostics. Never let this step itself fail the job;
+        # the real failure has already been recorded above.
+        set +e
+        echo "::group::Python environment"
         python --version
-        pip --version
-        python -c "import platform; print(platform.architecture())"
+        python -c "import sys, platform; print('exec:', sys.executable); print('arch:', platform.architecture())"
+        python -m pip list
+        echo "::endgroup::"
+        echo "::group::Relevant environment variables"
+        env | grep -E '^(PYTHON|PIP|PYTEST|KCONFIG_)' | sort
+        echo "::endgroup::"
+
+  # Slow kernel-conformance tests: checkout Linux v6.18, build the C kconfig
+  # tools, then diff our output against them. Runs in parallel with selftest.
+  conformance:
+    name: Conformance (Python ${{ matrix.target.python }}, ${{ matrix.target.os }})
+    runs-on: ${{ matrix.target.builder }}
+
+    defaults:
+      run:
+        shell: bash
+
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+        - python: '3.12'
+          os: Linux
+          builder: ubuntu-24.04
+        - python: '3.12'
+          os: macOS
+          builder: macos-15
+
+    steps:
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ matrix.target.python }}
 
     - name: Install Python dependencies
       run: |
+        set -euo pipefail
+        python -m pip install --user --upgrade pip
         python -m pip install --user setuptools wheel pytest
 
     - name: Install GNU toolchain (macOS)
@@ -67,14 +149,13 @@ jobs:
       # Makefile's unconditional LD=$(CROSS_COMPILE)ld assignment.
       if: ${{ matrix.target.os == 'macOS' }}
       run: |
+        set -euo pipefail
         brew install make lld
-        echo "$(brew --prefix make)/libexec/gnubin" >> $GITHUB_PATH
-        echo "$(brew --prefix lld)/bin" >> $GITHUB_PATH
-        echo "LD=ld.lld" >> $GITHUB_ENV
+        echo "$(brew --prefix make)/libexec/gnubin" >> "$GITHUB_PATH"
+        echo "$(brew --prefix lld)/bin" >> "$GITHUB_PATH"
+        echo "LD=ld.lld" >> "$GITHUB_ENV"
 
     - name: Check out Linux source code
-      # Skip for Windows (headless-only mode)
-      if: ${{ matrix.target.headless-only != true }}
       uses: actions/checkout@v6
       with:
         repository: torvalds/linux
@@ -83,54 +164,41 @@ jobs:
     - name: Check out Kconfiglib source code
       uses: actions/checkout@v6
       with:
-        # Windows (headless-only): checkout to root directory
-        # Linux/macOS (full test): checkout to Kconfiglib subdirectory
-        path: ${{ matrix.target.headless-only && '.' || 'Kconfiglib' }}
-
-    - name: Run pytest selftests
-      working-directory: ${{ matrix.target.headless-only && '.' || 'Kconfiglib' }}
-      run: |
-        if [ "${{ matrix.target.headless-only }}" == "true" ]; then
-          # Windows: portable subset -- excludes tests that need gcc or
-          # Unix shell commands (Kpreprocess uses $(shell,...) with
-          # bash-specific syntax).
-          python -m pytest tests/test_preprocess.py -v --tb=short \
-            -k "test_user_defined or test_success_failure or test_python_fn or test_kconfig_warn"
-        else
-          python -m pytest tests/ -v --tb=short --ignore=tests/test_conformance.py
-        fi
+        path: Kconfiglib
 
     - name: Apply Linux Kconfig Makefile patch
-      # Skip for Windows (headless-only mode)
-      if: ${{ matrix.target.headless-only != true }}
       run: |
+        set -euo pipefail
         git apply Kconfiglib/makefile.patch
 
     - name: Build kernel C kconfig tools
-      if: ${{ matrix.target.headless-only != true }}
       run: |
+        set -euo pipefail
         ${MAKE:-make} -j"$(getconf _NPROCESSORS_ONLN)" ARCH=x86 ${LD:+LD=$LD} allnoconfig
         test -x scripts/kconfig/conf
         rm -f .config .config.old
 
     - name: Run conformance tests and example scripts
-      # Skip for Windows (headless-only mode)
-      if: ${{ matrix.target.headless-only != true }}
       run: |
+        set -euo pipefail
         Kconfiglib/tests/reltest python
 
-    - name: Validate rawterm and menuconfig (Unix)
-      # Exercises rawterm Color/Style/Region compositing, terminal init/close
-      # (termios on Unix), and menuconfig headless mode with style parsing.
-      if: ${{ matrix.target.os != 'Windows' }}
-      working-directory: Kconfiglib
+    - name: Diagnostic dump on failure
+      if: failure()
       run: |
-        python .ci/validate-rawterm.py
-
-    - name: Validate rawterm and menuconfig (Windows)
-      # On Windows, use cmd so Python gets real console handles (bash
-      # runs through MSYS2/mintty which lacks a native Windows console).
-      if: ${{ matrix.target.os == 'Windows' }}
-      shell: cmd
-      run: |
-        python .ci/validate-rawterm.py
+        set +e
+        echo "::group::Kernel kconfig build artifacts"
+        ls -la scripts/kconfig/ 2>/dev/null
+        echo "::endgroup::"
+        echo "::group::Leftover .config (if any)"
+        cat .config 2>/dev/null | head -200
+        echo "::endgroup::"
+        echo "::group::Toolchain versions"
+        ${MAKE:-make} --version 2>/dev/null
+        ${LD:-ld} --version 2>/dev/null
+        cc --version 2>/dev/null
+        python --version
+        echo "::endgroup::"
+        echo "::group::Relevant environment variables"
+        env | grep -E '^(PYTHON|PIP|PYTEST|CC|HOSTCC|HOSTCXX|MAKE|LD|ARCH|SRCARCH|srctree|KERNELVERSION|KCONFIG_)' | sort
+        echo "::endgroup::"


### PR DESCRIPTION
The release pipeline was silently broken: release.yml invokes test.yml as reusable workflow, but test.yml only declared on: [push, pull_request], so any release trigger would fail immediately on the test job before reaching package or publish. Add workflow_call: to test.yml so reusable invocation resolves.

Split test.yml into independent selftest (Linux/macOS/Windows) and conformance (Linux/macOS) jobs. Fast pytest runs and rawterm validation no longer wait behind the slow kernel checkout, C-tools build, and reltest pipeline. Five matrix runs now execute in parallel instead of three sequential per-OS pipelines.

Consolidate exception handling across all four workflows. Every bash run block is hardened with set -euo pipefail, and every job ends with a uniform if: failure() diagnostic dump gated on set +e so the dump itself cannot mask the original failure. Dumps are scoped per job: Python/pip environment and KCONFIG_* vars for selftest; kernel kconfig build artifacts, leftover .config, and toolchain versions for conformance; dist/ and build/ listings for package; black diff and tool versions for style; release tag/draft/prerelease for release. Success-path output stays quiet; the rich diagnostics only appear when something actually broke.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the broken release pipeline by making the test workflow reusable from releases. CI now runs faster by splitting tests into parallel jobs and adds unified, scoped failure diagnostics.

- **Bug Fixes**
  - Added `workflow_call` to `test.yml` so `release.yml` can invoke it; release no longer fails before package/publish.

- **Refactors**
  - Split `test.yml` into `selftest` (Linux/macOS/Windows) and `conformance` (Linux/macOS); five matrix runs now execute in parallel for faster feedback.
  - Standardized shell to bash and hardened all steps with `set -euo pipefail`; added consistent `if: failure()` dumps scoped per job (tests, package, style, release).
  - Set `PYTEST_ADDOPTS` for clearer output; added `PIP_DISABLE_PIP_VERSION_CHECK` and `PYTHONUNBUFFERED`.
  - Listed build artifacts on success only where useful; richer diagnostics (env, tool versions, diffs) appear only on failure.

<sup>Written for commit 5e20500775c1ec5eea81558a52c3efd7e275a305. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

